### PR TITLE
Fix shellcheck lint warnings in setup scripts

### DIFF
--- a/compute_init/ubuntu/install_rancher.sh
+++ b/compute_init/ubuntu/install_rancher.sh
@@ -15,7 +15,7 @@ systemctl start rke2-server.service
 # ------------------------------
 # Wait for kubeconfig to exist
 # ------------------------------
-for i in {1..60}; do
+for _i in {1..60}; do
   [[ -f /etc/rancher/rke2/rke2.yaml ]] && break
   sleep 2
 done
@@ -57,7 +57,7 @@ systemctl restart rke2-server.service
 # ------------------------------
 export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
 
-for i in {1..90}; do
+for _i in {1..90}; do
   kubectl get --raw=/readyz >/dev/null 2>&1 && break
   sleep 2
 done

--- a/compute_init/ubuntu/setup.sh
+++ b/compute_init/ubuntu/setup.sh
@@ -42,6 +42,7 @@ scripts=(
 for script in "${scripts[@]}"; do
   log "Installing: $script"
   # Redirects both stdout and stderr (2>&1) to the log file in append mode (>>)
+  # shellcheck disable=SC2024
   if sudo -i -u ubuntu bash "$CYBR_DEMOS_PATH/compute_init/ubuntu/$script" >> "$log_file" 2>&1; then
     log "SUCCESS: $script installed."
   else

--- a/compute_init/ubuntu/setup_rancher.sh
+++ b/compute_init/ubuntu/setup_rancher.sh
@@ -24,10 +24,12 @@ log() {
 }
 
 run_as_root() {
+  # shellcheck disable=SC2024
   sudo -H bash -c "$*" >>"$log_file" 2>&1
 }
 
 run_as_ubuntu() {
+  # shellcheck disable=SC2024
   sudo -u ubuntu -H bash -c "$*" >>"$log_file" 2>&1
 }
 

--- a/demos/secrets_hub/asm/setup/secrets_hub/setup.sh
+++ b/demos/secrets_hub/asm/setup/secrets_hub/setup.sh
@@ -14,8 +14,8 @@ set_variables() {
   printf "\nSetting local vars from Env"
   isp_id=$TENANT_ID
   isp_subdomain=$TENANT_SUBDOMAIN
-  client_id=$CLIENT_ID
-  client_secret=$CLIENT_SECRET
+  export client_id=$CLIENT_ID
+  export client_secret=$CLIENT_SECRET
   safe_name=$SAFE_NAME
 }
 platform_auth() {

--- a/demos/secrets_hub/aws_cli/demo.sh
+++ b/demos/secrets_hub/aws_cli/demo.sh
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 export AWS_PROFILE=default
 
 aws sts get-caller-identity

--- a/demos/secrets_hub/hashi_vault/setup/cert_manager/setup.sh
+++ b/demos/secrets_hub/hashi_vault/setup/cert_manager/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Add the Jetstack Helm repository
 helm repo add jetstack https://charts.jetstack.io
 helm repo update

--- a/demos/secrets_hub/hashi_vault/setup/hashi_vault/setup.sh
+++ b/demos/secrets_hub/hashi_vault/setup/hashi_vault/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Get Hashi Cert
 resolve_template "cert_request.tmpl.yaml" "cert_request.yaml"
 kubectl apply -f cert_request.yaml
@@ -22,6 +23,7 @@ cat $vault_init_file
 vault_init_addr=$(grep -oP "VAULT_ADDR='\K[^']+" "$vault_init_file")
 
 # Extract Initial Root Token
+export vault_token
 vault_token=$(grep "Initial Root Token:" "$vault_init_file" | awk '{print $NF}')
 
 # Extract Unseal Keys

--- a/demos/secrets_hub/hashi_vault/setup/setup.sh
+++ b/demos/secrets_hub/hashi_vault/setup/setup.sh
@@ -9,8 +9,8 @@ set -a
 source "$demo_path/setup/vars.env"
 set +a
 
-sm_fqdn="$SM_FQDN"
-sm_namespace="$NAMESPACE"
+export sm_fqdn="$SM_FQDN"
+export sm_namespace="$NAMESPACE"
 
 # Setup Vault
 cd "$demo_path/setup/cert_manager"

--- a/demos/secrets_manager/k8s/setup.sh
+++ b/demos/secrets_manager/k8s/setup.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 # Print failing command + line number
+rc=0
 trap 'rc=$?; echo "[ERROR] line $LINENO: command failed: $BASH_COMMAND (exit=$rc)" >&2; exit $rc' ERR
 
 # Require CYBR_DEMOS_PATH (or provide a default)

--- a/demos/secrets_manager/summon_ubuntu/consumer.sh
+++ b/demos/secrets_manager/summon_ubuntu/consumer.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 echo ""
 echo "Env Variables"
 echo "SECRET1: $SECRET1"


### PR DESCRIPTION
## Summary
- Layers fork-specific shell lint fixes on top of the latest `upstream/main`.
- Keeps upstream structure changes intact while carrying only the remaining fork delta.
- Updates bash scripts to resolve shellcheck issues without changing intended behavior.

## Validation
- Cherry-picked the fork lint commit onto current `upstream/main`.
- Resolved path drift conflicts by keeping upstream layout and applying compatible changes.
- Verified clean branch state and pushed to fork branch `zach/layer-on-upstream`.

Made with [Cursor](https://cursor.com)