### PR TITLE
Add ESO + Conjur Cloud standalone sub-demo

### DIFF
--- a/demos/secrets_manager/k8s/README.md
+++ b/demos/secrets_manager/k8s/README.md
@@ -48,6 +48,20 @@ This demo includes these main patterns:
 - K8s Secrets FetchAll
 - Push To File
 - Push To File FetchAll
+- External Secrets Operator (standalone sub-demo)
+- direct `curl` authentication and retrieval
+
+### Sub-Demos
+
+| Directory | Pattern | Entry Point |
+|---|---|---|
+| `eso/` | External Secrets Operator — Conjur Cloud JWT auth (`refreshInterval: 15s`) | `bash eso/demo.sh` |
+
+### `eso/` manifests
+
+- **`secretstore.tmpl.yaml`** / **`externalsecret.yaml`** use namespace **`external-secrets`**. Render the SecretStore with `envsubst` and `TENANT_SUBDOMAIN` (see **`eso/demo_setup.md`**).
+- **`refreshInterval: 15s`** on the ExternalSecret for rotation walkthroughs.
+
 - External Secrets Operator
 - direct `curl` authentication and retrieval
 

--- a/demos/secrets_manager/k8s/check_prereqs.sh
+++ b/demos/secrets_manager/k8s/check_prereqs.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# One-shot triage for demos/secrets_manager/k8s before ./setup.sh
+# Usage (from anywhere):
+#   export CYBR_DEMOS_PATH=/path/to/cybr-demos
+#   bash "$CYBR_DEMOS_PATH/demos/secrets_manager/k8s/check_prereqs.sh"
+set -euo pipefail
+
+fail() {
+  printf '\n[FAIL] %s\n' "$1" >&2
+  exit 1
+}
+
+pass() { printf '[OK] %s\n' "$1"; }
+
+[[ -n "${CYBR_DEMOS_PATH:-}" ]] || fail "Set CYBR_DEMOS_PATH to the cybr-demos repo root."
+
+demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/k8s"
+vars_env="$demo_path/setup/vars.env"
+tenant_vars="$CYBR_DEMOS_PATH/demos/tenant_vars.sh"
+
+[[ -d "$demo_path" ]] || fail "Missing demo dir: $demo_path (wrong CYBR_DEMOS_PATH?)"
+[[ -f "$tenant_vars" ]] || fail "Missing $tenant_vars"
+[[ -f "$vars_env" ]] || fail "Missing $vars_env — create it from the template in this folder (see demo_setup.md)."
+
+printf '\n========== Secrets Manager / K8s — prerequisite check ==========\n\n'
+
+printf '%s\n' '--- 1) Local tools ---'
+for c in curl jq bash mktemp; do
+  command -v "$c" >/dev/null 2>&1 || fail "Missing required command: $c"
+done
+pass "curl, jq, bash, mktemp present"
+command -v kubectl >/dev/null 2>&1 || fail "kubectl not found — install kubectl and configure cluster access."
+pass "kubectl present"
+if command -v helm >/dev/null 2>&1; then
+  pass "helm present (required for setup/k8s/setup.sh — installs External Secrets Operator and the demo chart)"
+elif [[ "${SKIP_HELM_CHECK:-}" == "1" ]]; then
+  printf '%s\n' "[WARN] helm not in PATH — skipped because SKIP_HELM_CHECK=1. Install before ./setup.sh: macOS: brew install helm" >&2
+else
+  fail "helm not found — ./setup.sh needs Helm 3 for this demo (ESO + Helm chart). Install: macOS: brew install helm. Or validate CyberArk only: SKIP_HELM_CHECK=1 bash \"$demo_path/check_prereqs.sh\""
+fi
+
+printf '\n--- 2) Tenant credentials (demos/tenant_vars.sh) ---\n'
+set -a
+# shellcheck disable=SC1090
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+# shellcheck disable=SC1090
+source "$vars_env"
+set +a
+
+[[ -n "${TENANT_ID:-}" ]] || fail "TENANT_ID is empty after sourcing tenant_vars."
+[[ -n "${TENANT_SUBDOMAIN:-}" ]] || fail "TENANT_SUBDOMAIN is empty."
+[[ -n "${CLIENT_ID:-}" ]] || fail "CLIENT_ID is empty."
+[[ -n "${CLIENT_SECRET:-}" ]] || fail "CLIENT_SECRET is empty."
+
+if [[ "${CLIENT_ID:-}" == SET_* ]] || [[ "${CLIENT_SECRET:-}" == SET_* ]]; then
+  fail "CLIENT_ID / CLIENT_SECRET still look like placeholders in demos/tenant_vars.sh — set real OAuth confidential client credentials."
+fi
+pass "TENANT_ID=$TENANT_ID TENANT_SUBDOMAIN=$TENANT_SUBDOMAIN CLIENT_ID=$CLIENT_ID (secret not printed)"
+
+printf '\n--- 3) DNS: Identity (ISPSS) host ---\n'
+id_host="${TENANT_ID}.id.cyberark.cloud"
+if command -v host >/dev/null 2>&1; then
+  host "$id_host" || fail "DNS lookup failed for $id_host — fix network/VPN or TENANT_ID (must match https://<TENANT_ID>.id.cyberark.cloud)."
+elif command -v dscacheutil >/dev/null 2>&1; then
+  dscacheutil -q host -a name "$id_host" | head -n 5 || true
+else
+  printf '(skip DNS: install host(1) for DNS check)\n'
+fi
+pass "Resolved or skipped DNS for $id_host"
+
+printf '\n--- 4) ISPSS platform token (same as vault/setup.sh) ---\n'
+# Subshell: get_identity_token uses exit 1 on failure; we must not kill this script.
+# Pass credentials via env so special characters in CLIENT_SECRET cannot break quoting.
+export _K8S_PREQ_TENANT_ID="$TENANT_ID"
+export _K8S_PREQ_CLIENT_ID="$CLIENT_ID"
+export _K8S_PREQ_CLIENT_SECRET="$CLIENT_SECRET"
+outf=$(mktemp)
+set +e
+bash -euo pipefail -c '
+  export CYBR_DEMOS_PATH="'"$CYBR_DEMOS_PATH"'"
+  set -a
+  # shellcheck disable=SC1090
+  source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+  set +a
+  get_identity_token "$_K8S_PREQ_TENANT_ID" "$_K8S_PREQ_CLIENT_ID" "$_K8S_PREQ_CLIENT_SECRET"
+' >"$outf" 2>&1
+rc=$?
+set -e
+identity_token=$(cat "$outf")
+rm -f "$outf"
+unset _K8S_PREQ_TENANT_ID _K8S_PREQ_CLIENT_ID _K8S_PREQ_CLIENT_SECRET
+if [[ "$rc" -ne 0 || -z "$identity_token" ]]; then
+  printf '%s\n' "$identity_token" >&2
+  fail "get_identity_token failed (exit $rc). Fix TENANT_ID (ISPSS id), CLIENT_ID/SECRET, OAuth confidential client, roles; optional CYBERARK_OAUTH_APP_ID for /oauth2/token/<appId>."
+fi
+pass "Platform token acquired (${#identity_token} chars)"
+
+printf '\n--- 5) Secrets Manager / Conjur OIDC exchange ---\n'
+export _K8S_PREQ_SUBDOMAIN="$TENANT_SUBDOMAIN"
+export _K8S_PREQ_ID_TOKEN="$identity_token"
+outf=$(mktemp)
+set +e
+bash -euo pipefail -c '
+  export CYBR_DEMOS_PATH="'"$CYBR_DEMOS_PATH"'"
+  set -a
+  # shellcheck disable=SC1090
+  source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+  set +a
+  get_conjur_token "$_K8S_PREQ_SUBDOMAIN" "$_K8S_PREQ_ID_TOKEN"
+' >"$outf" 2>&1
+rc=$?
+set -e
+conjur_token=$(cat "$outf")
+rm -f "$outf"
+unset _K8S_PREQ_SUBDOMAIN _K8S_PREQ_ID_TOKEN
+if [[ "$rc" -ne 0 || -z "$conjur_token" ]]; then
+  printf '%s\n' "$conjur_token" >&2
+  fail "get_conjur_token failed (exit $rc). Check TENANT_SUBDOMAIN for *.secretsmgr.cyberark.cloud and Conjur permissions."
+fi
+pass "Conjur token acquired (${#conjur_token} chars)"
+
+printf '\n--- 6) Kubernetes cluster ---\n'
+kubectl get nodes >/dev/null || fail "kubectl get nodes failed — start cluster (e.g. minikube start) and fix kubeconfig context."
+pass "Kubernetes API reachable"
+
+printf '\n========== All checks passed. Run: cd \"%s\" && ./setup.sh ==========\n\n' "$demo_path"

--- a/demos/secrets_manager/k8s/eso/REFERENCES.md
+++ b/demos/secrets_manager/k8s/eso/REFERENCES.md
@@ -1,0 +1,64 @@
+# ESO + CyberArk Conjur Cloud — References
+
+Sources used to build, configure, and troubleshoot this demo.
+
+## External Secrets Operator
+
+| Resource | URL |
+|---|---|
+| ESO Conjur Provider (primary reference) | https://external-secrets.io/latest/provider/conjur/ |
+| ESO Conjur JWT Auth (Option 2) | https://external-secrets.io/latest/provider/conjur/#option-2-external-secret-store-with-jwt-authentication |
+| ESO Installation / Helm Chart | https://external-secrets.io/latest/introduction/getting-started/ |
+| ESO API — SecretStore | https://external-secrets.io/latest/api/secretstore/ |
+| ESO API — ExternalSecret | https://external-secrets.io/latest/api/externalsecret/ |
+| ESO GitHub Repo | https://github.com/external-secrets/external-secrets |
+| Accelerator-K8s-External-Secrets (CyberArk example repo) | https://github.com/conjurdemos/Accelerator-K8s-External-Secrets |
+
+## CyberArk Conjur Cloud
+
+| Resource | URL |
+|---|---|
+| Conjur Cloud JWT Authenticator Setup | https://docs.cyberark.com/conjur-cloud/latest/en/Content/Integrations/k8s-ocp/k8s-jwt-authn.htm |
+| Conjur JWT Authentication Guidelines | https://docs.cyberark.com/conjur-open-source/Latest/en/Content/Operations/Services/cjr-authn-jwt-guidelines.htm |
+| Conjur Policy Reference | https://docs.cyberark.com/conjur-cloud/latest/en/Content/Operations/Policy/policy-statement-ref.htm |
+| Conjur Cloud REST API | https://docs.cyberark.com/conjur-cloud/latest/en/Content/Developer/Conjur_API_v5.htm |
+| Conjur Synchronizer (Privilege Cloud to Conjur) | https://docs.cyberark.com/conjur-cloud/latest/en/Content/ConjurCloud/cl_ConjurSynchronizer.htm |
+
+## CyberArk Identity / ISPSS
+
+| Resource | URL |
+|---|---|
+| ISPSS OAuth2 Client Credentials Flow | https://docs.cyberark.com/identity/latest/en/Content/Developer/Developer-idp-OAuth2-ClientCreds.htm |
+| Privilege Cloud REST API — Safes | https://docs.cyberark.com/privilege-cloud-shared-services/latest/en/Content/SDK/Safes%20Web%20Services%20-%20List%20Safes.htm |
+| Privilege Cloud REST API — Accounts | https://docs.cyberark.com/privilege-cloud-shared-services/latest/en/Content/SDK/Add%20Account.htm |
+
+## Kubernetes
+
+| Resource | URL |
+|---|---|
+| K8s TokenRequest API (JWT source for ESO) | https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/ |
+| K8s ServiceAccount Tokens | https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
+| K8s Secrets | https://kubernetes.io/docs/concepts/configuration/secret/ |
+
+## Tools
+
+| Tool | URL |
+|---|---|
+| k9s — Terminal UI for Kubernetes | https://k9scli.io/ |
+| k9s GitHub | https://github.com/derailed/k9s |
+| Helm | https://helm.sh/ |
+| ShellCheck (used by this repo's CI) | https://www.shellcheck.net/ |
+
+## Key Decisions and Lessons Learned
+
+These came out of the actual build session and are documented here for future reference.
+
+**CLIENT_ID login suffix matters.** The CyberArk Identity service account login suffix must exactly match the tenant subdomain. `conjurinstaller@zach-lab` works; `conjurinstaller@zachlab` returns `access_denied`. The hyphen matters.
+
+**CLIENT_SECRET with special characters in bash.** Complex passwords containing `}`, `&`, `^`, etc. break `${VAR:-default}` parameter expansion. Use an `if/else` block with single-quoted direct assignment instead.
+
+**Conjur Sync must be a safe member before policy loading.** The `delegation/consumers` group for a safe only exists in Conjur after the Conjur Synchronizer (DAPService) has been added as a member of the safe in Privilege Cloud and completed its sync cycle.
+
+**identity-path must match the host's policy branch.** The JWT authenticator variable `conjur/authn-jwt/zg-eso/identity-path` is prepended to the JWT `sub` claim to resolve the Conjur host. If the host is defined at `data/poc-workloads/...`, the identity-path must be `data/poc-workloads` — not `data/k8s/eso` or any other path.
+
+**ESO webhook needs time to start.** After Helm install, the webhook and cert-controller pods must be fully ready before applying SecretStore resources. Use `kubectl rollout status` to gate on readiness.

--- a/demos/secrets_manager/k8s/eso/conjur-policy/1-workload.yaml
+++ b/demos/secrets_manager/k8s/eso/conjur-policy/1-workload.yaml
@@ -1,0 +1,15 @@
+# Policy branch: data
+# mode: append-policy
+#
+# Defines the poc-workloads policy and the ESO host identity.
+# The host's "sub" annotation must match the K8s service account JWT sub claim.
+---
+- !policy
+  id: poc-workloads
+  owner: !group /Conjur_Cloud_Admins
+  body:
+  - !host
+    id: system:serviceaccount:external-secrets:zg-eso-service-account
+    annotations:
+      authn-jwt/zg-eso/sub: system:serviceaccount:external-secrets:zg-eso-service-account
+      authn/api-key: true

--- a/demos/secrets_manager/k8s/eso/conjur-policy/2-grant-safe-access.yaml
+++ b/demos/secrets_manager/k8s/eso/conjur-policy/2-grant-safe-access.yaml
@@ -1,0 +1,15 @@
+# Policy branch: data
+# mode: append-policy
+#
+# Grants the ESO workload host consumer access to the k8s-eso safe.
+# The delegation/consumers group is created by the Conjur Synchronizer
+# after "Conjur Sync" is added as a safe member in Privilege Cloud.
+---
+- !policy
+  id: vault
+  body:
+    - !grant
+      roles:
+        - !group k8s-eso/delegation/consumers
+      members:
+        - !host /data/poc-workloads/system:serviceaccount:external-secrets:zg-eso-service-account

--- a/demos/secrets_manager/k8s/eso/conjur-policy/3-grant-authenticator-access.yaml
+++ b/demos/secrets_manager/k8s/eso/conjur-policy/3-grant-authenticator-access.yaml
@@ -1,0 +1,14 @@
+# Policy branch: conjur/authn-jwt
+# mode: append-policy
+#
+# Adds the ESO workload host to the zg-eso JWT authenticator's apps group,
+# allowing it to authenticate via authn-jwt/zg-eso.
+---
+- !policy
+  id: zg-eso
+  body:
+  - !grant
+    roles:
+      - !group apps
+    members:
+      - !host /data/poc-workloads/system:serviceaccount:external-secrets:zg-eso-service-account

--- a/demos/secrets_manager/k8s/eso/demo.sh
+++ b/demos/secrets_manager/k8s/eso/demo.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+# ESO + CyberArk Conjur Cloud Demo Script (~10 minutes)
+# Interactive walkthrough: press ENTER to advance between steps.
+set -euo pipefail
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+NAMESPACE="external-secrets"
+ESO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+pause() {
+  printf "\n${YELLOW}▶ Press ENTER to continue...${NC}"
+  read -r
+  echo
+}
+
+header() {
+  printf "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+  printf "${BOLD}  %s${NC}\n" "$1"
+  printf "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+}
+
+run_cmd() {
+  printf "${GREEN}\$ %s${NC}\n" "$*"
+  eval "$@"
+}
+
+# ─────────────────────────────────────────────────────────
+header "ESO + CyberArk Secrets Manager Demo"
+cat <<'INTRO'
+
+  This demo shows External Secrets Operator (ESO) pulling
+  credentials from CyberArk Conjur Cloud into Kubernetes
+  secrets — zero application code changes required.
+
+  Flow:
+    Privilege Cloud Safe → Conjur Sync → Conjur Cloud
+      → ESO (JWT auth) → K8s Secret
+
+INTRO
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 1: ESO Infrastructure"
+printf "ESO runs as a controller in the ${BOLD}external-secrets${NC} namespace.\n"
+printf "It watches for SecretStore and ExternalSecret resources.\n\n"
+run_cmd kubectl get pods -n "$NAMESPACE"
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 2: SecretStore — Conjur JWT Authentication"
+cat <<'TALK'
+
+  The SecretStore configures HOW to reach Conjur Cloud:
+    • URL:          Conjur Cloud API endpoint
+    • serviceID:    JWT authenticator (authn-jwt/zg-eso)
+    • account:      Conjur account name
+    • JWT source:   K8s service account token
+
+  When ESO needs a secret, it mints a JWT from the service
+  account and authenticates to Conjur via authn-jwt.
+
+TALK
+printf "${BOLD}SecretStore manifest:${NC}\n"
+run_cmd cat "$ESO_DIR/secretstore.yaml"
+pause
+
+printf "${BOLD}SecretStore status:${NC}\n"
+run_cmd kubectl get secretstore -n "$NAMESPACE" conjur -o wide
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 3: Service Account Identity"
+cat <<'TALK'
+
+  ESO uses a dedicated K8s service account to get a JWT.
+  The JWT 'sub' claim becomes the workload identity in Conjur:
+
+    system:serviceaccount:external-secrets:zg-eso-service-account
+
+  Conjur maps this to a host via identity-path + sub claim,
+  then checks safe membership before returning the secret.
+
+TALK
+run_cmd kubectl get sa -n "$NAMESPACE" zg-eso-service-account
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 4: Conjur Policy — Identity & Access"
+cat <<'TALK'
+
+  Three policies wire up the authorization in Conjur Cloud:
+
+  1. Workload host     — defines the identity + JWT annotation
+  2. Safe access grant — adds host to k8s-eso/delegation/consumers
+  3. Authenticator     — allows host to use authn-jwt/zg-eso
+
+TALK
+for f in "$ESO_DIR"/conjur-policy/*.yaml; do
+  printf "${BOLD}── $(basename "$f") ──${NC}\n"
+  cat "$f"
+  echo
+done
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 5: ExternalSecret — What To Fetch"
+cat <<'TALK'
+
+  The ExternalSecret defines WHAT secrets to pull:
+    • secretStoreRef:  points to the 'conjur' SecretStore
+    • remoteRef.key:   Conjur variable path
+    • target:          K8s Secret name to create
+
+  Conjur variable paths mirror Privilege Cloud structure:
+    data/vault/<safe>/<account>/<property>
+
+TALK
+run_cmd cat "$ESO_DIR/externalsecret.yaml"
+pause
+
+printf "${BOLD}ExternalSecret sync status:${NC}\n"
+run_cmd kubectl get externalsecret -n "$NAMESPACE" conjur -o wide
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 6: The Payoff — K8s Secret"
+cat <<'TALK'
+
+  ESO created a native K8s Secret from the Conjur variables.
+  Any pod in this namespace can mount it — no SDK, no sidecar,
+  no application changes needed.
+
+TALK
+run_cmd kubectl get secret -n "$NAMESPACE" conjur-secrets
+
+printf "\n${BOLD}Decoded values:${NC}\n"
+printf "  username: "
+kubectl get secret -n "$NAMESPACE" conjur-secrets -o jsonpath="{.data.username}" | base64 --decode
+printf "\n  password: "
+kubectl get secret -n "$NAMESPACE" conjur-secrets -o jsonpath="{.data.password}" | base64 --decode
+echo
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 7: Live Rotation Demo"
+
+BEFORE_PASS=$(kubectl get secret -n "$NAMESPACE" conjur-secrets -o jsonpath="{.data.password}" | base64 --decode)
+printf "${BOLD}Current password in K8s:${NC} %s\n" "$BEFORE_PASS"
+printf "${BOLD}Refresh interval:${NC}       "
+kubectl get externalsecret -n "$NAMESPACE" conjur -o jsonpath="{.spec.refreshInterval}"
+echo
+cat <<'TALK'
+
+  Now go to Privilege Cloud and change the password for
+  account-ssh-user-1 in the k8s-eso safe.
+
+  ESO will detect the change on the next sync cycle (≤15s).
+  This script will poll every 10 seconds and show you the
+  moment the K8s secret updates — live, no restart required.
+
+TALK
+printf "${YELLOW}▶ Change the password in Privilege Cloud, then press ENTER to start watching...${NC}"
+read -r
+
+printf "\n${BOLD}Watching for rotation...${NC}\n"
+POLL_COUNT=0
+MAX_POLLS=18
+while [ "$POLL_COUNT" -lt "$MAX_POLLS" ]; do
+  CURRENT_PASS=$(kubectl get secret -n "$NAMESPACE" conjur-secrets -o jsonpath="{.data.password}" | base64 --decode)
+  POLL_COUNT=$((POLL_COUNT + 1))
+  TIMESTAMP=$(date +"%H:%M:%S")
+
+  if [ "$CURRENT_PASS" != "$BEFORE_PASS" ]; then
+    printf "  ${GREEN}[%s] ✓ ROTATED${NC}\n" "$TIMESTAMP"
+    printf "\n${BOLD}Before:${NC} %s\n" "$BEFORE_PASS"
+    printf "${BOLD}After:${NC}  %s\n" "$CURRENT_PASS"
+    printf "\n${GREEN}Password updated in K8s — zero pod restarts, zero redeployments.${NC}\n"
+    break
+  fi
+
+  printf "  [%s] polling... password unchanged (%d/%d)\n" "$TIMESTAMP" "$POLL_COUNT" "$MAX_POLLS"
+  sleep 10
+done
+
+if [ "$POLL_COUNT" -eq "$MAX_POLLS" ]; then
+  printf "\n${RED}Timed out after 3 minutes. Verify the change propagated in Privilege Cloud.${NC}\n"
+  printf "Manual check: kubectl get secret -n %s conjur-secrets -o jsonpath=\"{.data.password}\" | base64 --decode\n" "$NAMESPACE"
+fi
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 8: Visual Exploration with k9s"
+cat <<'TALK'
+
+  k9s gives a live dashboard view of the ESO resources.
+
+  Suggested views once inside k9s:
+    :secretstores        — see Conjur connection status
+    :externalsecrets     — see sync status + last refresh
+    :secrets             — find conjur-secrets, press 'x' to decode
+    :pods                — ESO controller health
+
+  Press 'd' on any resource to describe, 'l' for logs.
+
+TALK
+printf "Launch k9s? (y/n) "
+read -r answer
+if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+  k9s -n "$NAMESPACE"
+fi
+
+# ─────────────────────────────────────────────────────────
+header "Demo Complete"
+cat <<'SUMMARY'
+
+  What we demonstrated:
+    ✓ ESO installed via Helm with CRDs
+    ✓ SecretStore with Conjur Cloud JWT authentication
+    ✓ K8s service account as workload identity
+    ✓ Conjur policy: host, safe access, authenticator grant
+    ✓ ExternalSecret pulling live credentials
+    ✓ Native K8s Secret — zero app changes
+    ✓ Automatic rotation via refresh interval
+
+  Key CyberArk value:
+    • Secrets stay in Privilege Cloud (single source of truth)
+    • Conjur Sync replicates to Conjur Cloud automatically
+    • JWT auth — no static API keys stored in the cluster
+    • Policy-as-code — all access grants are auditable YAML
+    • ESO is open-source — no vendor lock-in on the K8s side
+
+SUMMARY

--- a/demos/secrets_manager/k8s/eso/demo_setup.md
+++ b/demos/secrets_manager/k8s/eso/demo_setup.md
@@ -1,0 +1,131 @@
+# ESO + CyberArk Conjur Cloud — Demo Setup
+
+External Secrets Operator (ESO) pulls credentials from CyberArk Conjur Cloud into native Kubernetes secrets using JWT authentication. Secrets originate in Privilege Cloud and sync to Conjur Cloud automatically. ESO handles retrieval and rotation — zero application code changes.
+
+## Main Entry Point
+
+```bash
+bash demos/secrets_manager/k8s/eso/demo.sh
+```
+
+The interactive script walks through each layer of the integration with talk-track narration and live `kubectl` validation. Expect roughly 10 minutes end to end.
+
+## Deployment Context
+
+This demo runs on any Kubernetes cluster (Rancher, EKS, k3s, etc.) with outbound HTTPS to CyberArk Cloud. The lab deployment uses a single-node k3s cluster registered to Rancher.
+
+The demo relies on shared tenant configuration from `demos/tenant_vars.sh` and helper functions from `demos/setup_env.sh`.
+
+## Required Environment
+
+| Requirement | Detail |
+|---|---|
+| `CYBR_DEMOS_PATH` | Repo root path |
+| `demos/tenant_vars.sh` | `TENANT_ID`, `TENANT_SUBDOMAIN`, `CLIENT_ID`, `CLIENT_SECRET` |
+| CyberArk tenant | Privilege Cloud, Conjur Cloud, ISPSS |
+| Conjur JWT authenticator | `authn-jwt/zg-eso` configured with K8s OIDC as token source |
+| Privilege Cloud safe | `k8s-eso` with Conjur Sync as a member |
+| Kubernetes cluster | kubectl context set, Helm available |
+| k9s (optional) | For visual dashboard exploration |
+
+## Setup Flow
+
+### 1. Install External Secrets Operator
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update external-secrets
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace --set installCRDs=true
+```
+
+Wait for all pods to be ready:
+
+```bash
+kubectl rollout status deployment -n external-secrets external-secrets
+kubectl rollout status deployment -n external-secrets external-secrets-webhook
+kubectl rollout status deployment -n external-secrets external-secrets-cert-controller
+```
+
+### 2. Create the ESO service account
+
+```bash
+kubectl create sa zg-eso-service-account -n external-secrets
+```
+
+### 3. Configure CyberArk — Privilege Cloud
+
+1. Create a safe named `k8s-eso` in Privilege Cloud.
+2. Add **Conjur Sync** (DAPService) as a safe member with read access.
+3. Add the Conjur installer service account (`conjurinstaller@zach-lab`) with full admin access.
+4. Create an account `account-ssh-user-1` in the `k8s-eso` safe (Platform: Unix SSH).
+5. Wait for the Conjur Synchronizer to replicate the safe and account.
+
+### 4. Configure CyberArk — Conjur Cloud Policies
+
+Source the shared environment and obtain tokens:
+
+```bash
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+set +e; set +u
+identity_token=$(bash -c 'source "$CYBR_DEMOS_PATH/demos/setup_env.sh" && get_identity_token "$TENANT_ID" "$CLIENT_ID" "$CLIENT_SECRET"')
+conjur_token=$(bash -c "source \"\$CYBR_DEMOS_PATH/demos/setup_env.sh\" && get_conjur_token \"\$TENANT_SUBDOMAIN\" \"$identity_token\"")
+```
+
+Apply the three policies in order:
+
+```bash
+# 1. Create host identity (policy branch: data)
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "append" "data" \
+  demos/secrets_manager/k8s/eso/conjur-policy/1-workload.yaml
+
+# 2. Grant safe access (policy branch: data)
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "append" "data" \
+  demos/secrets_manager/k8s/eso/conjur-policy/2-grant-safe-access.yaml
+
+# 3. Grant authenticator access (policy branch: conjur/authn-jwt)
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "append" "conjur/authn-jwt" \
+  demos/secrets_manager/k8s/eso/conjur-policy/3-grant-authenticator-access.yaml
+```
+
+### 5. Set authenticator identity-path
+
+If the JWT authenticator's `identity-path` does not match the host's policy branch:
+
+```bash
+apply_conjur_secret "$TENANT_SUBDOMAIN" "$conjur_token" \
+  "conjur/authn-jwt/zg-eso/identity-path" "data/poc-workloads"
+```
+
+### 6. Apply K8s resources
+
+Set `TENANT_SUBDOMAIN` and optional `SM_AUTHN_ID` (defaults to `zg-eso`), then render and apply:
+
+```bash
+export TENANT_SUBDOMAIN=your-subdomain
+export SM_AUTHN_ID=zg-eso
+envsubst < demos/secrets_manager/k8s/eso/secretstore.tmpl.yaml | kubectl apply -f -
+kubectl apply -f demos/secrets_manager/k8s/eso/externalsecret.yaml
+```
+
+`secretstore.yaml` in the repo may contain a lab example URL; prefer `secretstore.tmpl.yaml` for new clusters.
+
+## What Gets Deployed
+
+| Resource | Kind | Namespace | Purpose |
+|---|---|---|---|
+| `external-secrets` | Deployment (3 pods) | `external-secrets` | ESO controller, webhook, cert-controller |
+| `zg-eso-service-account` | ServiceAccount | `external-secrets` | JWT identity for Conjur auth |
+| `conjur` | SecretStore | `external-secrets` | Conjur Cloud connection + JWT auth config |
+| `conjur` | ExternalSecret | `external-secrets` | Declares which Conjur variables to fetch |
+| `conjur-secrets` | Secret | `external-secrets` | Native K8s secret created by ESO |
+
+## Troubleshooting Setup
+
+| Symptom | Check |
+|---|---|
+| `no matches for kind "SecretStore"` | ESO CRDs not installed — reinstall with `--set installCRDs=true` |
+| Webhook connection refused | ESO pods not ready — `kubectl rollout status` all three deployments |
+| `policy_invalid` — group not found | Conjur Sync not added to the Privilege Cloud safe |
+| Identity token `access_denied` | Verify `CLIENT_ID` suffix matches tenant (`zach-lab` not `zachlab`) |
+| 401 on ExternalSecret sync | Check `identity-path` matches the host's policy branch |

--- a/demos/secrets_manager/k8s/eso/demo_validation.md
+++ b/demos/secrets_manager/k8s/eso/demo_validation.md
@@ -1,0 +1,296 @@
+# ESO + CyberArk Conjur Cloud — Demo Validation
+
+External Secrets Operator pulls credentials from CyberArk Conjur Cloud into native Kubernetes secrets via JWT authentication. Privilege Cloud is the single source of truth. Secrets sync through Conjur Cloud, and ESO handles the last mile into K8s.
+
+## Start Here
+
+Confirm your kubectl context and ESO namespace:
+
+```bash
+kubectl config current-context
+kubectl get ns external-secrets
+```
+
+All resources in this demo live in the `external-secrets` namespace.
+
+## About
+
+| Component | Role |
+|---|---|
+| **Privilege Cloud** | Source of truth — safes, accounts, passwords, rotation policies |
+| **Conjur Synchronizer** | Replicates Privilege Cloud safes and accounts into Conjur Cloud variables |
+| **Conjur Cloud** | Secrets manager — JWT authentication, policy-based access control, API retrieval |
+| **External Secrets Operator** | K8s controller — watches ExternalSecret CRs, authenticates to Conjur, writes K8s Secrets |
+| **K8s ServiceAccount** | Workload identity — JWT token is the authentication credential |
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph cyberark["CyberArk Cloud"]
+        direction LR
+        subgraph pc["Privilege Cloud"]
+            safe["Safe: k8s-eso\nAccount: ssh-user-1"]
+        end
+        subgraph cc["Conjur Cloud"]
+            authn["authn-jwt/zg-eso\nidentity-path: data/poc-workloads"]
+            host["Host: ...zg-eso-service-account\nGrant: k8s-eso/delegation/consumers"]
+        end
+        pc -- "Conjur Sync" --> cc
+    end
+
+    subgraph k8s["Kubernetes Cluster"]
+        subgraph eso["External Secrets Operator"]
+            ss["SecretStore — JWT auth to Conjur"]
+            es["ExternalSecret — fetches variables"]
+            sa["ServiceAccount: zg-eso-service-account\n(JWT sub = Conjur host identity)"]
+        end
+        secret["K8s Secret: conjur-secrets\nusername / password\nMountable by any pod in namespace"]
+        eso -- "creates / updates" --> secret
+    end
+
+    cc -- "REST API\n(JWT auth)" --> eso
+```
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    participant PC as Privilege Cloud
+    participant CS as Conjur Synchronizer
+    participant CC as Conjur Cloud
+    participant ESO as External Secrets Operator
+    participant SA as K8s ServiceAccount
+    participant KS as K8s Secret
+
+    PC->>CS: Account created or updated in safe k8s-eso
+    CS->>CC: Sync variables to data/vault/k8s-eso/...
+
+    ESO->>SA: Request JWT token (sub = SA name)
+    SA-->>ESO: Signed JWT
+
+    ESO->>CC: POST /authn-jwt/zg-eso/conjur/authenticate
+    Note over CC: Validate JWT signature via K8s OIDC<br/>Match sub claim to host identity<br/>Check host in authn-jwt/zg-eso/apps<br/>Check host in k8s-eso/delegation/consumers
+    CC-->>ESO: Conjur access token
+
+    ESO->>CC: GET /secrets/.../account-ssh-user-1/username
+    CC-->>ESO: username value
+    ESO->>CC: GET /secrets/.../account-ssh-user-1/password
+    CC-->>ESO: password value
+
+    ESO->>KS: Create or update Secret conjur-secrets
+    Note over KS: Native K8s Secret with decoded values
+```
+
+## Core Validation
+
+Verify ESO pods are running:
+
+```bash
+kubectl get pods -n external-secrets
+```
+
+Expected: three pods (`external-secrets`, `-webhook`, `-cert-controller`) all `Running` with `1/1` ready.
+
+Verify the service account exists:
+
+```bash
+kubectl get sa -n external-secrets zg-eso-service-account
+```
+
+## Pattern: JWT-Authenticated Secret Retrieval
+
+### What it does
+
+ESO uses the K8s service account JWT token to authenticate to Conjur Cloud. Conjur validates the JWT against the cluster's OIDC discovery endpoint, maps the `sub` claim to a host identity, checks group membership, and returns the requested secret values. ESO writes them into a native K8s Secret.
+
+### Identity and access controls
+
+| Layer | Control |
+|---|---|
+| **JWT token** | Minted from `zg-eso-service-account` in `external-secrets` namespace |
+| **Conjur host** | `data/poc-workloads/system:serviceaccount:external-secrets:zg-eso-service-account` |
+| **Authenticator** | `authn-jwt/zg-eso` — host must be in the `apps` group |
+| **Safe access** | Host must be in `data/vault/k8s-eso/delegation/consumers` |
+| **Identity path** | `data/poc-workloads` — prepended to JWT `sub` to resolve the host |
+
+### What to validate
+
+**SecretStore health:**
+
+```bash
+kubectl get secretstore -n external-secrets conjur
+kubectl describe secretstore -n external-secrets conjur
+```
+
+Look for `Status: Valid` and `Condition: Ready = True`. A failing SecretStore means the JWT auth handshake to Conjur is broken.
+
+**ExternalSecret sync status:**
+
+```bash
+kubectl get externalsecret -n external-secrets conjur
+kubectl describe externalsecret -n external-secrets conjur
+```
+
+Look for `Status: SecretSynced` and a recent `Last Synced Time`. The refresh interval of `15s` matches the eso-reloader demo — ESO re-fetches at most every 15 seconds.
+
+**K8s Secret contents:**
+
+```bash
+kubectl get secret -n external-secrets conjur-secrets -o yaml
+```
+
+Decode the values:
+
+```bash
+kubectl get secret -n external-secrets conjur-secrets \
+  -o jsonpath="{.data.username}" | base64 --decode && echo
+
+kubectl get secret -n external-secrets conjur-secrets \
+  -o jsonpath="{.data.password}" | base64 --decode && echo
+```
+
+### What the result proves
+
+- ESO can reach Conjur Cloud over HTTPS.
+- The JWT from `zg-eso-service-account` passes Conjur signature validation.
+- The `sub` claim maps to the correct host via `identity-path`.
+- The host has authenticator access (`authn-jwt/zg-eso/apps`) and safe access (`k8s-eso/delegation/consumers`).
+- Conjur returned the variable values and ESO wrote them to a native K8s Secret.
+- No static API key, no sidecar, no init container — controller-based sync only.
+
+### CyberArk behavior
+
+When ESO triggers a sync:
+
+1. ESO requests a JWT from the K8s TokenRequest API for `zg-eso-service-account` with audience `https://conjur.cyberark.com`.
+2. ESO POSTs the JWT to Conjur's `authn-jwt/zg-eso` endpoint.
+3. Conjur fetches the cluster's JWKS keys via the configured `jwks-uri` to validate the signature.
+4. Conjur extracts the `sub` claim and prepends `identity-path` to resolve the full host ID.
+5. Conjur checks the host is a member of `authn-jwt/zg-eso/apps`.
+6. For each variable request, Conjur checks the host has `read` and `execute` on the variable, granted via `k8s-eso/delegation/consumers`.
+7. Conjur returns the secret value. ESO base64-encodes it into the K8s Secret.
+
+## Rotation Behavior
+
+Password changes in Privilege Cloud propagate automatically:
+
+1. Password changed or rotated in Privilege Cloud.
+2. Conjur Synchronizer picks up the change (typically within seconds).
+3. On the next ESO refresh interval (15 seconds), ESO re-authenticates and fetches the updated value.
+4. ESO updates the K8s Secret in place — no pod restart, no redeployment.
+
+Verify the refresh interval:
+
+```bash
+kubectl get externalsecret -n external-secrets conjur \
+  -o jsonpath="{.spec.refreshInterval}" && echo
+```
+
+The `demo.sh` script includes a live rotation step that captures the current password, waits for you to change it in Privilege Cloud, then polls every 10 seconds until the K8s secret updates.
+
+## Visual Exploration with k9s
+
+k9s provides a live terminal dashboard for Kubernetes resources. It is significantly more engaging for demos than raw `kubectl` output.
+
+### Install
+
+```bash
+brew install derailed/k9s/k9s    # macOS
+curl -sS https://webi.sh/k9s | sh  # Linux
+```
+
+### Launch
+
+```bash
+k9s -n external-secrets
+```
+
+### Recommended Views
+
+| Shortcut | View | What to show |
+|---|---|---|
+| `:secretstores` | SecretStore list | `conjur` with `Valid` status |
+| `:externalsecrets` | ExternalSecret list | Sync status and last refresh time |
+| `:secrets` | Secret list | `conjur-secrets` — press `x` to decode live |
+| `:pods` | Pod list | ESO controller health — press `l` for logs |
+| `:events` | Cluster events | Real-time sync events |
+
+### Key Bindings
+
+| Key | Action |
+|---|---|
+| `x` | Decode secret values (on a secret resource) |
+| `d` | Describe resource — full status and conditions |
+| `l` | Tail logs (on a pod) |
+| `/` | Filter — type a string to narrow the list |
+| `Esc` | Go back one view |
+| `:q` | Quit k9s |
+
+### Demo Flow in k9s
+
+1. `:secretstores` — show `conjur` connection is `Valid` and `Ready`.
+2. `:externalsecrets` — show `SecretSynced` status with `LAST SYNC` timer.
+3. `:secrets` — highlight `conjur-secrets`, press `x` to decode values live.
+
+This three-view sequence tells the full story in about a minute.
+
+### Rotation Demo with k9s
+
+For maximum visual impact:
+
+1. Open k9s to `:secrets` and decode `conjur-secrets` with `x`.
+2. In a second terminal or browser tab, change the password in Privilege Cloud.
+3. Watch k9s. Within about one refresh interval (15s) plus Conjur sync latency, the secret value updates in the decoded view.
+4. No pod restart, no redeployment — the audience sees it happen live.
+
+## Troubleshooting
+
+### SecretStore not valid
+
+```bash
+kubectl describe secretstore -n external-secrets conjur
+```
+
+| Condition | Likely cause |
+|---|---|
+| `could not validate` | Conjur URL unreachable or TLS issue |
+| `401 Unauthorized` | JWT authenticator misconfigured, host not in `apps` group, or `identity-path` mismatch |
+| `connect: connection refused` | ESO webhook pods not ready — wait for rollout |
+
+### ExternalSecret not syncing
+
+```bash
+kubectl describe externalsecret -n external-secrets conjur
+```
+
+| Condition | Likely cause |
+|---|---|
+| `SecretSyncedError` | SecretStore is unhealthy — fix SecretStore first |
+| `401 Unauthorized` | Host missing safe access grant (`delegation/consumers`) |
+| `404 Not Found` | Variable path wrong — check `data/vault/<safe>/<account>/<property>` |
+| `403 Forbidden` | Host authenticated but lacks `read`/`execute` on the variable |
+
+### Conjur policy debugging
+
+Verify the host exists:
+
+```bash
+curl -s -H "Authorization: Token token=\"$conjur_token\"" \
+  "https://$TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud/api/resources/conjur/host/data%2Fpoc-workloads%2Fsystem%3Aserviceaccount%3Aexternal-secrets%3Azg-eso-service-account"
+```
+
+Check authenticator configuration:
+
+```bash
+curl -s -H "Authorization: Token token=\"$conjur_token\"" \
+  "https://$TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud/api/resources/conjur?search=authn-jwt/zg-eso"
+```
+
+### ESO controller logs
+
+```bash
+kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=50
+```
+
+Look for `reconcile error`, `401`, or `could not authenticate` messages.

--- a/demos/secrets_manager/k8s/eso/externalsecret.yaml
+++ b/demos/secrets_manager/k8s/eso/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: conjur
+  namespace: external-secrets
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: conjur
+    kind: SecretStore
+  target:
+    name: conjur-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: data/vault/k8s-eso/account-ssh-user-1/username
+    - secretKey: password
+      remoteRef:
+        key: data/vault/k8s-eso/account-ssh-user-1/password

--- a/demos/secrets_manager/k8s/eso/secretstore.tmpl.yaml
+++ b/demos/secrets_manager/k8s/eso/secretstore.tmpl.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: conjur
+  namespace: external-secrets
+spec:
+  provider:
+    conjur:
+      url: https://${TENANT_SUBDOMAIN}.secretsmgr.cyberark.cloud/api
+      auth:
+        jwt:
+          account: conjur
+          serviceID: ${SM_AUTHN_ID}
+          serviceAccountRef:
+            name: zg-eso-service-account
+            audiences:
+              - https://conjur.cyberark.com

--- a/demos/secrets_manager/k8s/eso/secretstore.yaml
+++ b/demos/secrets_manager/k8s/eso/secretstore.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: conjur
+  namespace: external-secrets
+spec:
+  provider:
+    conjur:
+      # Service URL
+      url: https://zach-lab.secretsmgr.cyberark.cloud/api
+      # [OPTIONAL] base64 encoded string of certificate
+     # caBundle: OPTIONALxFIELDxxxBase64xCertxString==
+      auth:
+        jwt:
+          # conjur account
+          account: conjur
+          # The authn-jwt service ID
+          serviceID: zg-eso
+          # Service account to retrieve JWT token for
+          serviceAccountRef:
+            name: zg-eso-service-account
+            # [OPTIONAL] audiences to include in JWT token
+            audiences:
+              - https://conjur.cyberark.com

--- a/demos/secrets_manager/k8s/setup.sh
+++ b/demos/secrets_manager/k8s/setup.sh
@@ -34,8 +34,17 @@ for f in "${req[@]}"; do
   [[ -f "$f" ]] || { echo "[ERROR] missing file: $f" >&2; exit 1; }
 done
 
+if [[ -f "$demo_path/check_prereqs.sh" ]] && [[ "${SKIP_K8S_PREREQ_CHECK:-}" != "1" ]]; then
+  echo "[INFO] Running $demo_path/check_prereqs.sh (set SKIP_K8S_PREREQ_CHECK=1 to skip)"
+  bash "$demo_path/check_prereqs.sh" || {
+    echo "[ERROR] Prerequisite check failed. Fix the issues above, then re-run ./setup.sh" >&2
+    exit 1
+  }
+fi
+
 # Optional: ensure executable (won't hurt if already)
 chmod +x \
+  "$demo_path/check_prereqs.sh" \
   "$demo_path/setup/k8s/init_rancher.sh" \
   "$demo_path/setup/vault/setup.sh" \
   "$demo_path/setup/sm/setup.sh" \

--- a/demos/secrets_manager/k8s/setup/k8s/charts/poc-sm/templates/demo-eso-sm.yaml
+++ b/demos/secrets_manager/k8s/setup/k8s/charts/poc-sm/templates/demo-eso-sm.yaml
@@ -31,7 +31,7 @@ metadata:
   name: conjur
   namespace: {{ .Values.namespace }}
 spec:
-  refreshInterval: 1m
+  refreshInterval: 15s
   secretStoreRef:
     # This name must match the metadata.name in the `SecretStore`
     name: conjur

--- a/demos/secrets_manager/k8s/setup/k8s/init_rancher.sh
+++ b/demos/secrets_manager/k8s/setup/k8s/init_rancher.sh
@@ -12,9 +12,10 @@ demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/k8s"
 # In prod a https service might be used with below to publicly expose jwks
 # curl -s https://127.0.0.1/openid/v1/jwks
 
-# Checks verify JWKS:
+# Checks verify JWKS (use cluster-relative paths so kubeconfig works on any API endpoint;
+# avoid hardcoded https://localhost:6443 — that only applies when the API is tunneled locally.)
 printf "\n\njwks jq formated\n"
-kubectl get --raw "https://localhost:6443/openid/v1/jwks" --insecure-skip-tls-verify | jq .
+kubectl get --raw /openid/v1/jwks | jq .
 printf "\n\nopenid-configurations\n"
 kubectl get --raw /.well-known/openid-configuration || echo "no discovery"
 printf "\n\njwks raw\n"


### PR DESCRIPTION
## Summary

- Adds `demos/secrets_manager/k8s/eso/` — interactive `demo.sh`, `demo_setup.md`, `demo_validation.md`, Conjur policy YAML, and ESO manifests.
- Introduces `secretstore.tmpl.yaml` (render with `envsubst` + `TENANT_SUBDOMAIN` / `SM_AUTHN_ID`) so manifests are not tied to a single tenant FQDN.
- Adds `check_prereqs.sh` and wires it into parent `setup.sh` (skippable via `SKIP_K8S_PREREQ_CHECK=1`).
- Aligns Helm `demo-eso-sm.yaml` to `refreshInterval: 15s`.

## Test plan

- [ ] `source demos/setup_env.sh` and configure Privilege Cloud safe `k8s-eso` + Conjur Sync per `eso/demo_setup.md`
- [ ] Install ESO via Helm (`installCRDs=true`)
- [ ] `envsubst < eso/secretstore.tmpl.yaml | kubectl apply -f -` and apply `externalsecret.yaml`
- [ ] Apply Conjur policies in order; set `identity-path` if needed
- [ ] `bash eso/demo.sh` — SecretStore Valid, ExternalSecret synced, live rotation in Privilege Cloud updates K8s Secret

## Notes

- Lab example `secretstore.yaml` may still contain a sample URL; prefer `secretstore.tmpl.yaml` for new clusters.
- Follow-up PRs (separate): Secrets Provider **sidecar** sub-demo, **eso-reloader** rotation story.

Made with [Cursor](https://cursor.com)