### PR TITLE
Add Secrets Provider for Kubernetes sidecar sub-demo

### DIFF
--- a/demos/secrets_manager/k8s/README.md
+++ b/demos/secrets_manager/k8s/README.md
@@ -48,6 +48,21 @@ This demo includes these main patterns:
 - K8s Secrets FetchAll
 - Push To File
 - Push To File FetchAll
+- Secrets Provider for Kubernetes (sidecar sub-demo)
+- direct `curl` authentication and retrieval
+
+### Sub-Demos
+
+| Directory | Pattern | Entry Point |
+|---|---|---|
+| `sidecar/` | CyberArk Secrets Provider — sidecar + `k8s_secrets`, 15s refresh | `bash sidecar/setup.sh` then `bash sidecar/demo.sh` |
+
+### `sidecar/` notes
+
+- Namespace **`sp-sidecar`**. Reuses safe **`k8s-eso`** and JWT authenticator **`authn-jwt/zg-eso`** (same as the ESO sub-demo when present).
+- **`setup.sh`** fetches the Conjur TLS cert, applies Conjur policy, and restarts the app after the sidecar populates **`db-credentials`**.
+- For local **minikube**, `setup.sh` can repoint the JWT authenticator JWKS — re-run **`setup/k8s/init_rancher.sh`** before returning to a Rancher lab cluster.
+
 - External Secrets Operator
 - direct `curl` authentication and retrieval
 

--- a/demos/secrets_manager/k8s/sidecar/conjur-policy/1-workload.yaml
+++ b/demos/secrets_manager/k8s/sidecar/conjur-policy/1-workload.yaml
@@ -1,0 +1,14 @@
+# Policy branch: data
+# mode: append-policy
+#
+# Defines the Secrets Provider sidecar host identity under poc-workloads.
+# The host's "sub" annotation must match the K8s service account JWT sub claim.
+---
+- !policy
+  id: poc-workloads
+  body:
+  - !host
+    id: system:serviceaccount:sp-sidecar:sp-sidecar-sa
+    annotations:
+      authn-jwt/zg-eso/sub: system:serviceaccount:sp-sidecar:sp-sidecar-sa
+      authn/api-key: true

--- a/demos/secrets_manager/k8s/sidecar/conjur-policy/2-grant-safe-access.yaml
+++ b/demos/secrets_manager/k8s/sidecar/conjur-policy/2-grant-safe-access.yaml
@@ -1,0 +1,13 @@
+# Policy branch: data
+# mode: append-policy
+#
+# Grants the sidecar workload host consumer access to the k8s-eso safe.
+---
+- !policy
+  id: vault
+  body:
+    - !grant
+      roles:
+        - !group k8s-eso/delegation/consumers
+      members:
+        - !host /data/poc-workloads/system:serviceaccount:sp-sidecar:sp-sidecar-sa

--- a/demos/secrets_manager/k8s/sidecar/conjur-policy/3-grant-authenticator-access.yaml
+++ b/demos/secrets_manager/k8s/sidecar/conjur-policy/3-grant-authenticator-access.yaml
@@ -1,0 +1,13 @@
+# Policy branch: conjur/authn-jwt
+# mode: append-policy
+#
+# Adds the sidecar workload host to the zg-eso JWT authenticator apps group.
+---
+- !policy
+  id: zg-eso
+  body:
+  - !grant
+    roles:
+      - !group apps
+    members:
+      - !host /data/poc-workloads/system:serviceaccount:sp-sidecar:sp-sidecar-sa

--- a/demos/secrets_manager/k8s/sidecar/demo.sh
+++ b/demos/secrets_manager/k8s/sidecar/demo.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+# Secrets Provider sidecar + CyberArk Conjur Cloud Demo Script (~10 minutes)
+# Interactive walkthrough: press ENTER to advance between steps.
+set -euo pipefail
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+NAMESPACE="sp-sidecar"
+SECRET_NAME="db-credentials"
+DEPLOYMENT="sidecar-demo-app"
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+pause() {
+  printf "\n${YELLOW}▶ Press ENTER to continue...${NC}"
+  read -r
+  echo
+}
+
+header() {
+  printf "\n${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+  printf "${BOLD}  %s${NC}\n" "$1"
+  printf "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+}
+
+run_cmd() {
+  printf "${GREEN}\$ %s${NC}\n" "$*"
+  eval "$@"
+}
+
+get_app_pod() {
+  kubectl get pods -n "$NAMESPACE" -l app="$DEPLOYMENT" --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
+}
+
+# ─────────────────────────────────────────────────────────
+header "Secrets Provider Sidecar + CyberArk Demo"
+cat <<'INTRO'
+
+  This demo shows the CyberArk Secrets Provider for Kubernetes
+  running as a SIDECAR — it authenticates with a pod JWT, fetches
+  Conjur variables, and writes a native Kubernetes Secret.
+
+  Flow:
+    Privilege Cloud Safe → Conjur Sync → Conjur Cloud
+      → Secrets Provider sidecar (JWT auth) → K8s Secret
+
+  Compare to ESO: no ExternalSecret CRDs — the provider runs
+  beside your app container in the same pod.
+
+INTRO
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 1: Pod Architecture — App + Sidecar"
+cat <<'TALK'
+
+  One pod, two containers:
+    • app          — your workload (reads K8s Secret via env)
+    • cyberark-secrets-provider-for-k8s — sidecar
+
+  The sidecar shares the pod service account JWT and refreshes
+  the K8s Secret on an interval (15s in this demo).
+
+TALK
+run_cmd kubectl get pods -n "$NAMESPACE" -l app="$DEPLOYMENT"
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 2: Conjur Connection — conjur-connect ConfigMap"
+cat <<'TALK'
+
+  The sidecar reads CyberArk connection settings from a ConfigMap:
+    • CONJUR_APPLIANCE_URL  — Conjur Cloud API
+    • CONJUR_AUTHN_URL      — authn-jwt endpoint
+    • AUTHENTICATOR_ID      — JWT authenticator service ID
+
+TALK
+run_cmd kubectl get configmap -n "$NAMESPACE" conjur-connect -o yaml
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 3: Service Account Identity"
+cat <<'TALK'
+
+  The pod service account mints a projected JWT (audience: conjur).
+  The JWT 'sub' claim is the workload identity in Conjur:
+
+    system:serviceaccount:sp-sidecar:sp-sidecar-sa
+
+TALK
+run_cmd kubectl get sa -n "$NAMESPACE" sp-sidecar-sa
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 4: Conjur Policy — Identity & Access"
+cat <<'TALK'
+
+  Three policies wire up authorization (same k8s-eso safe as ESO):
+
+  1. Workload host     — defines identity + JWT sub annotation
+  2. Safe access grant — adds host to k8s-eso/delegation/consumers
+  3. Authenticator     — allows host to use authn-jwt/zg-eso
+
+TALK
+for f in "$DEMO_DIR"/conjur-policy/*.yaml; do
+  printf "${BOLD}── $(basename "$f") ──${NC}\n"
+  cat "$f"
+  echo
+done
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 5: Secret Mapping — conjur-map"
+cat <<'TALK'
+
+  The db-credentials Secret tells the sidecar WHICH Conjur variables
+  to fetch and HOW to name them in Kubernetes:
+
+    username → data/vault/k8s-eso/account-ssh-user-1/username
+    password → data/vault/k8s-eso/account-ssh-user-1/password
+
+  The sidecar populates the secret keys; the app never talks to Conjur.
+
+TALK
+run_cmd cat "$DEMO_DIR/secret.yaml"
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 6: Deployment — Sidecar Annotations & Env"
+cat <<'TALK'
+
+  Pod annotations enable refresh without redeploying:
+    conjur.org/container-mode: sidecar
+    conjur.org/secrets-refresh-enabled: "true"
+    conjur.org/secrets-refresh-interval: 15s
+
+  Sidecar env:
+    CONTAINER_MODE=sidecar
+    K8S_SECRETS=db-credentials
+    SECRETS_DESTINATION=k8s_secrets
+
+TALK
+run_cmd cat "$DEMO_DIR/deployment.yaml"
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 7: The Payoff — K8s Secret"
+cat <<'TALK'
+
+  The sidecar created/updated a native K8s Secret from Conjur.
+  Inspect the data keys (not conjur-map — that is the mapping spec).
+
+TALK
+run_cmd kubectl get secret -n "$NAMESPACE" "$SECRET_NAME"
+
+printf "\n${BOLD}Decoded values:${NC}\n"
+printf "  username: "
+kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.username}" | base64 --decode
+printf "\n  password: "
+kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode
+echo
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 8: Application Consumption"
+cat <<'TALK'
+
+  The app container reads the secret via secretKeyRef env vars.
+  Note: env vars are fixed at container start — after rotation the
+  K8s Secret updates first; the app may need a restart to pick up
+  new env values (see eso-reloader/ for the Reloader pattern).
+
+TALK
+APP_POD=$(get_app_pod)
+if [ -n "$APP_POD" ]; then
+  run_cmd kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_USERNAME
+  run_cmd kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD
+else
+  printf "${RED}No running app pod found.${NC}\n"
+fi
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 9: Sidecar Logs"
+cat <<'TALK'
+
+  The provider sidecar logs authentication and secret sync events.
+  Useful when debugging JWT or Conjur policy issues.
+
+TALK
+if [ -n "$APP_POD" ]; then
+  run_cmd kubectl logs -n "$NAMESPACE" "$APP_POD" -c cyberark-secrets-provider-for-k8s --tail=30
+else
+  APP_POD=$(get_app_pod)
+  [ -n "$APP_POD" ] && run_cmd kubectl logs -n "$NAMESPACE" "$APP_POD" -c cyberark-secrets-provider-for-k8s --tail=30
+fi
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 10: Live Rotation Demo"
+
+BEFORE_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+printf "${BOLD}Current password in K8s:${NC} %s\n" "$BEFORE_PASS"
+cat <<'TALK'
+
+  Go to Privilege Cloud and change the password for
+  account-ssh-user-1 in the k8s-eso safe.
+
+  The sidecar refreshes every 15 seconds and updates the K8s Secret.
+  This script polls every 10 seconds until the secret changes.
+
+TALK
+printf "${YELLOW}▶ Change the password in Privilege Cloud, then press ENTER to start watching...${NC}"
+read -r
+
+printf "\n${BOLD}Watching K8s Secret for rotation...${NC}\n"
+POLL_COUNT=0
+MAX_POLLS=18
+while [ "$POLL_COUNT" -lt "$MAX_POLLS" ]; do
+  CURRENT_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+  POLL_COUNT=$((POLL_COUNT + 1))
+  TIMESTAMP=$(date +"%H:%M:%S")
+
+  if [ "$CURRENT_PASS" != "$BEFORE_PASS" ]; then
+    printf "  ${GREEN}[%s] ✓ ROTATED${NC}\n" "$TIMESTAMP"
+    printf "\n${BOLD}Before:${NC} %s\n" "$BEFORE_PASS"
+    printf "${BOLD}After:${NC}  %s\n" "$CURRENT_PASS"
+    printf "\n${GREEN}K8s Secret updated by the sidecar — no ESO controller required.${NC}\n"
+    break
+  fi
+
+  printf "  [%s] polling... password unchanged (%d/%d)\n" "$TIMESTAMP" "$POLL_COUNT" "$MAX_POLLS"
+  sleep 10
+done
+
+if [ "$POLL_COUNT" -eq "$MAX_POLLS" ]; then
+  printf "\n${RED}Timed out after 3 minutes. Check Privilege Cloud and sidecar logs.${NC}\n"
+  printf "Manual check: kubectl get secret -n %s %s -o jsonpath=\"{.data.password}\" | base64 --decode\n" "$NAMESPACE" "$SECRET_NAME"
+fi
+pause
+
+# ─────────────────────────────────────────────────────────
+header "Step 11: Visual Exploration with k9s"
+cat <<'TALK'
+
+  Suggested views in k9s (namespace sp-sidecar):
+    :pods     — two containers per pod; 'l' on sidecar for logs
+    :secrets  — db-credentials; press 'x' to decode
+    :sa       — sp-sidecar-sa workload identity
+
+TALK
+printf "Launch k9s? (y/n) "
+read -r answer
+if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+  k9s -n "$NAMESPACE"
+fi
+
+# ─────────────────────────────────────────────────────────
+header "Demo Complete"
+cat <<'SUMMARY'
+
+  What we demonstrated:
+    ✓ CyberArk Secrets Provider for K8s as a sidecar
+    ✓ Pod JWT → authn-jwt/zg-eso → Conjur Cloud
+    ✓ conjur-map Secret defines variable → key mapping
+    ✓ Native K8s Secret populated beside the app
+    ✓ 15s refresh interval — live rotation into K8s
+
+  vs ESO (demos/secrets_manager/k8s/eso/):
+    • Sidecar: provider in-pod, no cluster-wide ESO install
+    • ESO:     cluster controller + SecretStore / ExternalSecret CRDs
+
+  Key CyberArk value:
+    • Privilege Cloud remains the source of truth
+    • JWT auth — no static API keys in the cluster
+    • Policy-as-code Conjur grants — auditable YAML
+    • Works with standard secretKeyRef / volume mounts
+
+SUMMARY

--- a/demos/secrets_manager/k8s/sidecar/demo_setup.md
+++ b/demos/secrets_manager/k8s/sidecar/demo_setup.md
@@ -1,0 +1,101 @@
+# Secrets Provider Sidecar + CyberArk Conjur Cloud — Demo Setup
+
+The CyberArk **Secrets Provider for Kubernetes** runs as a **sidecar** container beside your application. It authenticates with a pod JWT, fetches Conjur variables, and writes a native Kubernetes Secret — no External Secrets Operator required.
+
+## Main Entry Points
+
+```bash
+bash demos/secrets_manager/k8s/sidecar/setup.sh
+bash demos/secrets_manager/k8s/sidecar/demo.sh
+```
+
+The interactive `demo.sh` script follows the same ENTER-to-advance style as `eso/demo.sh`. Expect roughly 10 minutes end to end.
+
+## Deployment Context
+
+This demo runs on any Kubernetes cluster with outbound HTTPS to CyberArk Cloud. It reuses the same Privilege Cloud safe (`k8s-eso`) and JWT authenticator (`authn-jwt/zg-eso`) as the ESO sub-demos.
+
+The demo relies on `CYBR_DEMOS_PATH`, `demos/tenant_vars.sh`, and `demos/setup_env.sh`.
+
+## Required Environment
+
+| Requirement | Detail |
+|---|---|
+| `CYBR_DEMOS_PATH` | Repo root path |
+| `demos/tenant_vars.sh` | `TENANT_ID`, `TENANT_SUBDOMAIN`, `CLIENT_ID`, `CLIENT_SECRET` |
+| CyberArk tenant | Privilege Cloud, Conjur Cloud, ISPSS |
+| Conjur JWT authenticator | `authn-jwt/zg-eso` with K8s OIDC as token source |
+| Privilege Cloud safe | `k8s-eso` with Conjur Sync as a member |
+| Kubernetes cluster | `kubectl` context set; cluster can pull `cyberark/secrets-provider-for-k8s` |
+
+Optional: `SM_AUTHN_ID` (defaults to `zg-eso` in `setup.sh`).
+
+## Relationship to the ESO Demos
+
+| | `eso/` | `sidecar/` |
+|---|---|---|
+| Integration | External Secrets Operator | Secrets Provider for K8s |
+| Where it runs | Cluster-wide controller | Sidecar in the app pod |
+| Declarative API | SecretStore + ExternalSecret | `conjur-map` on a K8s Secret + pod annotations |
+| Namespace | `external-secrets` | `sp-sidecar` |
+| Safe | `k8s-eso` | `k8s-eso` (shared) |
+| Refresh | `refreshInterval: 15s` | `conjur.org/secrets-refresh-interval: 15s` |
+
+If you already ran the ESO demo, the safe, account, and Conjur Sync replication are in place.
+
+## Setup Flow
+
+### 1. Privilege Cloud safe
+
+Reuse the `k8s-eso` safe from `eso/demo_setup.md` if it does not exist yet.
+
+### 2. Run setup.sh
+
+`setup.sh`:
+
+1. Creates namespace `sp-sidecar`, service account, and RBAC for secret updates.
+2. Builds `conjur-connect` ConfigMap (Conjur URLs + TLS cert fetched from `TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud`).
+3. Applies the `db-credentials` secret mapping (`conjur-map`).
+4. Applies three Conjur policies when tenant credentials are available.
+5. Deploys `sidecar-demo-app` and waits for the sidecar to populate secret keys.
+
+### 3. Manual policy application (if needed)
+
+```bash
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+identity_token=$(get_identity_token "$TENANT_ID" "$CLIENT_ID" "$CLIENT_SECRET")
+conjur_token=$(get_conjur_token "$TENANT_SUBDOMAIN" "$identity_token")
+
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+  "$(cat demos/secrets_manager/k8s/sidecar/conjur-policy/1-workload.yaml)"
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+  "$(cat demos/secrets_manager/k8s/sidecar/conjur-policy/2-grant-safe-access.yaml)"
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "conjur/authn-jwt" \
+  "$(cat demos/secrets_manager/k8s/sidecar/conjur-policy/3-grant-authenticator-access.yaml)"
+```
+
+## What Gets Deployed
+
+| Resource | Kind | Namespace | Purpose |
+|---|---|---|---|
+| `sp-sidecar-sa` | ServiceAccount | `sp-sidecar` | JWT workload identity |
+| `conjur-connect` | ConfigMap | `sp-sidecar` | Conjur URL + authn-jwt settings |
+| `db-credentials` | Secret | `sp-sidecar` | `conjur-map` + populated username/password keys |
+| `sidecar-demo-app` | Deployment | `sp-sidecar` | App + `cyberark-secrets-provider-for-k8s` sidecar |
+
+## Cleanup
+
+```bash
+bash demos/secrets_manager/k8s/sidecar/remove.sh
+```
+
+## Troubleshooting Setup
+
+| Symptom | Check |
+|---|---|
+| Secret has only `conjur-map`, no `username`/`password` | Sidecar logs: `kubectl logs -n sp-sidecar deploy/sidecar-demo-app -c cyberark-secrets-provider-for-k8s` |
+| 401 / auth failure | Host in `authn-jwt/zg-eso/apps` and `k8s-eso/delegation/consumers` |
+| `policy_invalid` — group not found | Conjur Sync on the `k8s-eso` safe in Privilege Cloud |
+| `CONJUR_SSL_CERTIFICATE` missing | Re-run `setup.sh` — cert is fetched via openssl from your Conjur Cloud FQDN |
+| ConfigMap URLs wrong | `TENANT_SUBDOMAIN` when running `setup.sh`; re-run after fixing |
+| Image pull errors | Cluster egress to Docker Hub for `cyberark/secrets-provider-for-k8s` |

--- a/demos/secrets_manager/k8s/sidecar/demo_validation.md
+++ b/demos/secrets_manager/k8s/sidecar/demo_validation.md
@@ -1,0 +1,122 @@
+# Secrets Provider Sidecar + CyberArk Conjur Cloud — Demo Validation
+
+Assume `setup.sh` completed successfully. This walkthrough validates the sidecar integration and explains CyberArk behavior.
+
+## Start Here
+
+```bash
+kubectl config current-context
+kubectl get ns sp-sidecar
+kubectl get pods -n sp-sidecar -l app=sidecar-demo-app
+```
+
+Expected: one pod with **2/2** containers ready (`app` + `cyberark-secrets-provider-for-k8s`).
+
+## About
+
+| Component | Role |
+|---|---|
+| **Privilege Cloud** | Source of truth — `k8s-eso` safe, account passwords |
+| **Conjur Synchronizer** | Replicates safe contents to Conjur variables |
+| **Conjur Cloud** | JWT auth, policy, secret retrieval API |
+| **Secrets Provider sidecar** | In-pod agent — JWT auth, fetch, write K8s Secret |
+| **K8s ServiceAccount** | `sp-sidecar-sa` — JWT `sub` = Conjur host identity |
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph cyberark["CyberArk Cloud"]
+        pc["Privilege Cloud\nSafe: k8s-eso"]
+        cc["Conjur Cloud\nauthn-jwt/zg-eso"]
+        pc -->|Conjur Sync| cc
+    end
+
+    subgraph pod["Pod: sidecar-demo-app"]
+        app["app container\nsecretKeyRef env"]
+        sp["cyberark-secrets-provider-for-k8s\nsidecar"]
+        sa["ServiceAccount JWT"]
+        app -->|reads| ks["K8s Secret\ndb-credentials"]
+        sp -->|creates/updates| ks
+        sa --> sp
+    end
+
+    cc -->|REST JWT auth| sp
+```
+
+## Core Validation
+
+**ConfigMap:**
+
+```bash
+kubectl get configmap -n sp-sidecar conjur-connect -o yaml
+```
+
+**Secret mapping and populated keys:**
+
+```bash
+kubectl get secret -n sp-sidecar db-credentials -o yaml
+kubectl get secret -n sp-sidecar db-credentials -o jsonpath="{.data.username}" | base64 --decode && echo
+kubectl get secret -n sp-sidecar db-credentials -o jsonpath="{.data.password}" | base64 --decode && echo
+```
+
+**App env consumption:**
+
+```bash
+POD=$(kubectl get pod -n sp-sidecar -l app=sidecar-demo-app -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n sp-sidecar "$POD" -c app -- printenv DB_USERNAME DB_PASSWORD
+```
+
+**Sidecar logs:**
+
+```bash
+kubectl logs -n sp-sidecar "$POD" -c cyberark-secrets-provider-for-k8s --tail=50
+```
+
+## Identity and Access Controls
+
+| Layer | Control |
+|---|---|
+| **JWT token** | Projected SA token, audience `conjur` |
+| **Conjur host** | `data/poc-workloads/system:serviceaccount:sp-sidecar:sp-sidecar-sa` |
+| **Authenticator** | `authn-jwt/zg-eso` — host in `apps` group |
+| **Safe access** | `k8s-eso/delegation/consumers` |
+
+## Rotation Behavior
+
+1. Change password in Privilege Cloud for `account-ssh-user-1` in safe `k8s-eso`.
+2. Conjur Sync updates Conjur variables.
+3. Sidecar refresh (15s) re-fetches and patches `db-credentials`.
+4. Validate:
+
+```bash
+watch -n 5 'kubectl get secret -n sp-sidecar db-credentials -o jsonpath="{.data.password}" | base64 --decode; echo'
+```
+
+Or run the live rotation section in `demo.sh`.
+
+**Note:** `secretKeyRef` environment variables do not update until the app container restarts. For automatic rollout after secret change, see `eso-reloader/`.
+
+## Compare to ESO
+
+| Aspect | Sidecar (`sidecar/`) | ESO (`eso/`) |
+|---|---|---|
+| Install footprint | Per-pod sidecar image | Cluster-wide ESO + CRDs |
+| Configuration | Secret `conjur-map` + annotations | SecretStore + ExternalSecret |
+| Secret writer | Provider container | ESO controller |
+| Typical buyer story | Minimal deps, co-located with app | GitOps-friendly CRDs, multi-namespace |
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Pod 1/2 not ready | Sidecar logs; Conjur policy grants |
+| Empty `username`/`password` keys | `conjur-map` paths; safe sync status |
+| Secret never updates on rotation | `conjur.org/secrets-refresh-enabled`; sidecar logs |
+| App shows old password | Expected for env vars — restart pod or use Reloader |
+
+## Interactive Demo
+
+```bash
+bash demos/secrets_manager/k8s/sidecar/demo.sh
+```

--- a/demos/secrets_manager/k8s/sidecar/deployment.yaml
+++ b/demos/secrets_manager/k8s/sidecar/deployment.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sidecar-demo-app
+  namespace: sp-sidecar
+  labels:
+    app: sidecar-demo-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sidecar-demo-app
+  template:
+    metadata:
+      labels:
+        app: sidecar-demo-app
+      annotations:
+        conjur.org/container-mode: sidecar
+        conjur.org/secrets-refresh-enabled: "true"
+        conjur.org/secrets-refresh-interval: 15s
+        conjur.org/debug-logging: "true"
+        conjur.org/log-traces: "true"
+    spec:
+      serviceAccountName: sp-sidecar-sa
+      containers:
+        - name: app
+          image: alpine/curl
+          imagePullPolicy: IfNotPresent
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: password
+          volumeMounts:
+            - name: conjur-status
+              mountPath: /conjur/status
+              readOnly: true
+            - name: jwt-token
+              mountPath: /var/run/secrets/tokens
+              readOnly: true
+        - name: cyberark-secrets-provider-for-k8s
+          image: cyberark/secrets-provider-for-k8s:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: conjur-status
+              mountPath: /conjur/status
+            - name: jwt-token
+              mountPath: /var/run/secrets/tokens
+            - name: podinfo
+              mountPath: /conjur/podinfo
+          env:
+            - name: DEBUG
+              value: "true"
+            - name: JWT_TOKEN_PATH
+              value: /var/run/secrets/tokens/jwt
+            - name: CONTAINER_MODE
+              value: sidecar
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_SECRETS
+              value: db-credentials
+            - name: SECRETS_DESTINATION
+              value: k8s_secrets
+          envFrom:
+            - configMapRef:
+                name: conjur-connect
+      volumes:
+        - name: conjur-status
+          emptyDir:
+            medium: Memory
+        - name: jwt-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: jwt
+                  expirationSeconds: 6000
+                  audience: conjur
+        - name: podinfo
+          downwardAPI:
+            items:
+              - path: annotations
+                fieldRef:
+                  fieldPath: metadata.annotations

--- a/demos/secrets_manager/k8s/sidecar/namespace.yaml
+++ b/demos/secrets_manager/k8s/sidecar/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sp-sidecar
+  labels:
+    demo: sp-sidecar

--- a/demos/secrets_manager/k8s/sidecar/rbac.yaml
+++ b/demos/secrets_manager/k8s/sidecar/rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secrets-access
+  namespace: sp-sidecar
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secrets-access-binding
+  namespace: sp-sidecar
+subjects:
+  - kind: ServiceAccount
+    name: sp-sidecar-sa
+    namespace: sp-sidecar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secrets-access

--- a/demos/secrets_manager/k8s/sidecar/remove.sh
+++ b/demos/secrets_manager/k8s/sidecar/remove.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Cleanup: CyberArk Secrets Provider for K8s — sidecar mode
+set -euo pipefail
+
+NAMESPACE="sp-sidecar"
+
+echo "[INFO] Removing Secrets Provider sidecar demo"
+
+kubectl delete deployment -n "$NAMESPACE" sidecar-demo-app --ignore-not-found
+kubectl delete secret -n "$NAMESPACE" db-credentials --ignore-not-found
+kubectl delete configmap -n "$NAMESPACE" conjur-connect --ignore-not-found
+kubectl delete sa -n "$NAMESPACE" sp-sidecar-sa --ignore-not-found
+kubectl delete rolebinding -n "$NAMESPACE" secrets-access-binding --ignore-not-found
+kubectl delete role -n "$NAMESPACE" secrets-access --ignore-not-found
+kubectl delete ns "$NAMESPACE" --ignore-not-found
+
+echo "[INFO] Cleanup complete"
+echo "[NOTE] Conjur policies are not removed. Remove host grants manually if needed."

--- a/demos/secrets_manager/k8s/sidecar/secret.yaml
+++ b/demos/secrets_manager/k8s/sidecar/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-credentials
+  namespace: sp-sidecar
+type: Opaque
+stringData:
+  # Placeholders so the app container can start; the sidecar overwrites these keys.
+  username: pending
+  password: pending
+  conjur-map: |-
+    username: data/vault/k8s-eso/account-ssh-user-1/username
+    password: data/vault/k8s-eso/account-ssh-user-1/password

--- a/demos/secrets_manager/k8s/sidecar/service-account.yaml
+++ b/demos/secrets_manager/k8s/sidecar/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sp-sidecar-sa
+  namespace: sp-sidecar

--- a/demos/secrets_manager/k8s/sidecar/setup.sh
+++ b/demos/secrets_manager/k8s/sidecar/setup.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Setup: CyberArk Secrets Provider for K8s — sidecar mode
+set -euo pipefail
+
+trap 'rc=$?; echo "[ERROR] line $LINENO: $BASH_COMMAND (exit=$rc)" >&2; exit $rc' ERR
+
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+NAMESPACE="sp-sidecar"
+
+export CYBR_DEMOS_PATH="${CYBR_DEMOS_PATH:-/opt/cybr-demos}"
+
+echo "[INFO] Setting up Secrets Provider sidecar demo"
+echo "[INFO] CYBR_DEMOS_PATH=$CYBR_DEMOS_PATH"
+echo "[INFO] DEMO_DIR=$DEMO_DIR"
+
+if [[ -f "$CYBR_DEMOS_PATH/demos/setup_env.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+fi
+
+SM_AUTHN_ID="${SM_AUTHN_ID:-zg-eso}"
+if [[ -z "${TENANT_SUBDOMAIN:-}" ]]; then
+  echo "[ERROR] TENANT_SUBDOMAIN is not set. Source demos/tenant_vars.sh or demos/setup_env.sh first."
+  exit 1
+fi
+
+export TENANT_SUBDOMAIN SM_AUTHN_ID
+
+# Minikube (and other local clusters) use a different JWKS than Rancher lab nodes.
+# Point the shared JWT authenticator at this cluster when the current context is minikube.
+sync_jwt_authenticator_for_current_cluster() {
+  local conjur_token="$1"
+  local ctx jwks validation_value issuer
+
+  ctx=$(kubectl config current-context 2>/dev/null || true)
+  if [[ "$ctx" != minikube ]]; then
+    return 0
+  fi
+
+  if ! kubectl get --raw /openid/v1/jwks >/dev/null 2>&1; then
+    echo "[WARN] minikube context but /openid/v1/jwks unavailable — skipping JWKS sync"
+    return 0
+  fi
+
+  echo "[INFO] minikube detected — updating authn-jwt/${SM_AUTHN_ID} public-keys for this cluster"
+  jwks=$(kubectl get --raw /openid/v1/jwks)
+  validation_value=$(jq -cn --argjson jwks "$jwks" '{type:"jwks", value:$jwks}')
+  issuer=$(kubectl create token sp-sidecar-sa -n sp-sidecar --audience conjur --duration 60s 2>/dev/null \
+    | python3 -c "import sys,json,base64; t=sys.stdin.read().strip().split('.')[1]; t+='='*(-len(t)%4); print(json.loads(base64.urlsafe_b64decode(t))['iss'])" 2>/dev/null \
+    || echo "https://kubernetes.default.svc.cluster.local")
+
+  apply_conjur_secret "$TENANT_SUBDOMAIN" "$conjur_token" \
+    "conjur/authn-jwt/${SM_AUTHN_ID}/public-keys" "$validation_value"
+  apply_conjur_secret "$TENANT_SUBDOMAIN" "$conjur_token" \
+    "conjur/authn-jwt/${SM_AUTHN_ID}/issuer" "$issuer"
+  echo "[INFO] JWT authenticator issuer set to: $issuer"
+  echo "[NOTE] Re-run k8s/setup/k8s/init_rancher.sh to restore Rancher JWKS when switching back to the lab cluster."
+}
+
+echo "[INFO] Applying namespace and RBAC"
+kubectl apply -f "$DEMO_DIR/namespace.yaml"
+kubectl apply -f "$DEMO_DIR/service-account.yaml"
+kubectl apply -f "$DEMO_DIR/rbac.yaml"
+
+echo "[INFO] Rendering conjur-connect ConfigMap"
+sm_fqdn="${TENANT_SUBDOMAIN}.secretsmgr.cyberark.cloud"
+conjur_ssl_certificate=$(openssl s_client -connect "${sm_fqdn}:443" -servername "$sm_fqdn" </dev/null 2>/dev/null \
+  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p')
+if [[ -z "$conjur_ssl_certificate" ]]; then
+  echo "[ERROR] Failed to fetch Conjur SSL certificate from ${sm_fqdn}"
+  exit 1
+fi
+cert_file=$(mktemp)
+trap 'rm -f "$cert_file"' EXIT
+printf '%s\n' "$conjur_ssl_certificate" > "$cert_file"
+kubectl create configmap conjur-connect -n "$NAMESPACE" \
+  --from-literal="CONJUR_ACCOUNT=conjur" \
+  --from-literal="CONJUR_APPLIANCE_URL=https://${sm_fqdn}/api" \
+  --from-literal="CONJUR_AUTHN_URL=https://${sm_fqdn}/api/authn-jwt/${SM_AUTHN_ID}" \
+  --from-literal="AUTHENTICATOR_ID=${SM_AUTHN_ID}" \
+  --from-literal="CONJUR_VERSION=5" \
+  --from-file="CONJUR_SSL_CERTIFICATE=${cert_file}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "[INFO] Applying secret mapping and deployment"
+kubectl apply -f "$DEMO_DIR/secret.yaml"
+
+if [[ -n "${TENANT_ID:-}" && -n "${CLIENT_ID:-}" && -n "${CLIENT_SECRET:-}" ]]; then
+  echo "[INFO] Obtaining CyberArk tokens"
+  identity_token=$(get_identity_token "$TENANT_ID" "$CLIENT_ID" "$CLIENT_SECRET")
+  conjur_token=$(get_conjur_token "$TENANT_SUBDOMAIN" "$identity_token")
+
+  sync_jwt_authenticator_for_current_cluster "$conjur_token"
+
+  echo "[INFO] Applying Conjur policies"
+  apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+    "$(cat "$DEMO_DIR/conjur-policy/1-workload.yaml")"
+  apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+    "$(cat "$DEMO_DIR/conjur-policy/2-grant-safe-access.yaml")"
+  apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "conjur/authn-jwt" \
+    "$(cat "$DEMO_DIR/conjur-policy/3-grant-authenticator-access.yaml")"
+else
+  echo "[WARN] Tenant credentials not set — skipping Conjur policy setup."
+  echo "[WARN] Apply conjur-policy/*.yaml manually before the sidecar can authenticate."
+fi
+
+kubectl apply -f "$DEMO_DIR/deployment.yaml"
+kubectl rollout status deployment -n "$NAMESPACE" sidecar-demo-app --timeout=180s
+
+echo "[INFO] Waiting for sidecar to populate db-credentials..."
+for _ in $(seq 1 24); do
+  if kubectl get secret -n "$NAMESPACE" db-credentials -o jsonpath='{.data.username}' 2>/dev/null | grep -q .; then
+    echo "[INFO] Secret db-credentials is populated"
+    break
+  fi
+  sleep 5
+done
+
+kubectl get secret -n "$NAMESPACE" db-credentials -o wide 2>/dev/null || true
+
+echo "[INFO] Restarting app so secretKeyRef env vars pick up populated keys"
+kubectl rollout restart deployment -n "$NAMESPACE" sidecar-demo-app
+kubectl rollout status deployment -n "$NAMESPACE" sidecar-demo-app --timeout=120s
+
+echo "[INFO] Setup complete — run: bash $DEMO_DIR/demo.sh"


### PR DESCRIPTION
## Summary

- Adds `demos/secrets_manager/k8s/sidecar/` — CyberArk **Secrets Provider for K8s** in **sidecar** mode with `k8s_secrets` destination and **15s** refresh annotations.
- Includes `setup.sh` (Conjur TLS cert fetch, policy apply, optional minikube JWKS sync), interactive `demo.sh`, and validation docs.
- Documents coexistence with the ESO sub-demo (shared `k8s-eso` safe + `authn-jwt/zg-eso`).

## Test plan

- [ ] Merge or complete setup from ESO sub-demo PR (safe `k8s-eso`, JWT authenticator) — https://github.com/David-Lang/cybr-demos/pull/28
- [ ] `bash sidecar/setup.sh` with `demos/setup_env.sh` sourced
- [ ] Pod reaches `2/2` Ready; `db-credentials` has `username` / `password` keys
- [ ] `bash sidecar/demo.sh` — live rotation updates K8s Secret without ESO

## Notes

- **Merge after #28** (or ensure `k8s-eso` safe and `zg-eso` authenticator exist) to avoid README / policy conflicts.
- Minikube `setup.sh` repoints JWT `public-keys`; re-run `setup/k8s/init_rancher.sh` when returning to a Rancher lab cluster.
- Companion PR: **eso-reloader** (ESO + Stakater Reloader rotation walkthrough).

Made with [Cursor](https://cursor.com)