### PR TITLE
Add ESO + Reloader auto-rotation sub-demo

### DIFF
--- a/demos/secrets_manager/k8s/README.md
+++ b/demos/secrets_manager/k8s/README.md
@@ -48,6 +48,20 @@ This demo includes these main patterns:
 - K8s Secrets FetchAll
 - Push To File
 - Push To File FetchAll
+- ESO auto-rotation with sample app (sub-demo)
+- direct `curl` authentication and retrieval
+
+### Sub-Demos
+
+| Directory | Pattern | Entry Point |
+|---|---|---|
+| `eso-reloader/` | ESO 15s refresh + volume/env consumption + Stakater Reloader | `bash eso-reloader/setup.sh` then `bash eso-reloader/demo.sh` |
+
+### `eso-reloader/` notes
+
+- Namespace **`eso-reloader`**. Shares **`k8s-eso`** safe and **`authn-jwt/zg-eso`** with the ESO sub-demo.
+- Demonstrates volume mount auto-update vs env vars requiring pod restart (Reloader automates restart).
+
 - External Secrets Operator
 - direct `curl` authentication and retrieval
 

--- a/demos/secrets_manager/k8s/eso-reloader/conjur-policy/1-workload.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/conjur-policy/1-workload.yaml
@@ -1,0 +1,14 @@
+# Policy branch: data
+# mode: append-policy
+#
+# Defines the ESO reloader host identity under the shared poc-workloads policy.
+# The host's "sub" annotation must match the K8s service account JWT sub claim.
+---
+- !policy
+  id: poc-workloads
+  body:
+  - !host
+    id: system:serviceaccount:eso-reloader:eso-reloader-sa
+    annotations:
+      authn-jwt/zg-eso/sub: system:serviceaccount:eso-reloader:eso-reloader-sa
+      authn/api-key: true

--- a/demos/secrets_manager/k8s/eso-reloader/conjur-policy/2-grant-safe-access.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/conjur-policy/2-grant-safe-access.yaml
@@ -1,0 +1,16 @@
+# Policy branch: data
+# mode: append-policy
+#
+# Grants the ESO reloader workload host consumer access to the
+# k8s-eso safe (shared with the existing ESO demo).
+# The delegation/consumers group is created by the Conjur Synchronizer
+# after "Conjur Sync" is added as a safe member in Privilege Cloud.
+---
+- !policy
+  id: vault
+  body:
+    - !grant
+      roles:
+        - !group k8s-eso/delegation/consumers
+      members:
+        - !host /data/poc-workloads/system:serviceaccount:eso-reloader:eso-reloader-sa

--- a/demos/secrets_manager/k8s/eso-reloader/conjur-policy/3-grant-authenticator-access.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/conjur-policy/3-grant-authenticator-access.yaml
@@ -1,0 +1,14 @@
+# Policy branch: conjur/authn-jwt
+# mode: append-policy
+#
+# Adds the ESO reloader workload host to the zg-eso JWT authenticator's
+# apps group, allowing it to authenticate via authn-jwt/zg-eso.
+---
+- !policy
+  id: zg-eso
+  body:
+  - !grant
+    roles:
+      - !group apps
+    members:
+      - !host /data/poc-workloads/system:serviceaccount:eso-reloader:eso-reloader-sa

--- a/demos/secrets_manager/k8s/eso-reloader/demo.sh
+++ b/demos/secrets_manager/k8s/eso-reloader/demo.sh
@@ -152,6 +152,14 @@ require_app_pod() {
   printf "%s" "$pod"
 }
 
+get_env_password() {
+  local pod="$1"
+  if [ -z "$pod" ]; then
+    return 0
+  fi
+  kubectl exec -n "$NAMESPACE" "$pod" -c app -- printenv DB_PASSWORD 2>/dev/null || true
+}
+
 brand_bar() {
   printf "${ACCENT}${BOLD}  %-54s${NC}\n" "  CyberArk Conjur Cloud · ESO · Reloader"
 }
@@ -504,6 +512,26 @@ while [ "$POLL_COUNT" -lt "$MAX_POLLS" ]; do
     printf "\n"
     status_ok "K8s Secret auto-rotated"
     status_ok "Zero code changes, zero manual intervention"
+
+    # Capture env vars immediately — Reloader often restarts the pod within seconds.
+    ROTATED_PASS="$CURRENT_PASS"
+    ROTATION_POD_AT_DETECT=$(get_app_pod)
+    ENV_PASS_AT_ROTATION=$(get_env_password "$ROTATION_POD_AT_DETECT")
+
+    printf "\n    ${BOLD}Snapshot (same second as Secret update):${NC}\n"
+    box_top 52
+    box_row 52 "  ${BOLD}K8s Secret password:${NC}  ${ACCENT}updated${NC}"
+    if [ -n "$ENV_PASS_AT_ROTATION" ] && [ "$ENV_PASS_AT_ROTATION" != "$ROTATED_PASS" ]; then
+      box_row 52 "  ${BOLD}DB_PASSWORD env:${NC}     ${ERR}still ${ENV_PASS_AT_ROTATION}${NC}"
+      box_row 52 "  ${DIM}(frozen at container start — Reloader has not rolled yet)${NC}"
+      status_warn "Env var still stale — step 11 will use this snapshot"
+    elif [ -n "$ENV_PASS_AT_ROTATION" ] && [ "$ENV_PASS_AT_ROTATION" = "$ROTATED_PASS" ]; then
+      box_row 52 "  ${BOLD}DB_PASSWORD env:${NC}     ${ACCENT}already ${ENV_PASS_AT_ROTATION}${NC}"
+      status_warn "Reloader was very fast — step 11 replays the stale-env story from this snapshot"
+    else
+      box_row 52 "  ${BOLD}DB_PASSWORD env:${NC}     ${DIM}(pod not ready to inspect)${NC}"
+    fi
+    box_bot 52
     break
   fi
 
@@ -519,20 +547,12 @@ if [ "$POLL_COUNT" -eq "$MAX_POLLS" ]; then
   printf "    ${DIM}3. kubectl get externalsecret -n %s db-credentials${NC}\n" "$NAMESPACE"
 fi
 
-# Jump to k9s right after the Secret changes so the audience can watch Reloader roll the
-# deployment before the scripted kubelet/env waits (those can take minutes).
-ROTATED_PASS_CHECK=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
-if [ "$ROTATED_PASS_CHECK" != "$BEFORE_PASS" ]; then
-  printf "\n    ${BOLD}Reloader reacts to this Secret change next.${NC}\n"
-  printf "    ${DIM}Live view: ${BOLD}:pods${DIM} — new pod name / age (clearest for Reloader). ${BOLD}:events${DIM} — Scheduled/Pulled/Started (optional, noisier).${NC}\n\n"
-  printf "    ${EMPH}Open k9s now to watch the rollout? [Y/n] ${NC}"
-  read -r k9s_early
-  case "${k9s_early:-y}" in
-    [nN]*) ;;
-    *) k9s -n "$NAMESPACE" ;;
-  esac
+if [ -z "${ROTATED_PASS:-}" ]; then
+  ROTATED_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
 fi
 
+printf "\n    ${DIM}Next: volume mount catches up (~60–90s), then the env-var / Reloader story.${NC}\n"
+printf "    ${DIM}Reloader may restart the pod during step 10 — we captured env at rotation above.${NC}\n"
 pause
 
 # ═══════════════════════════════════════════════════════════
@@ -551,7 +571,7 @@ printf "\n"
 
 printf "    ${BOLD}Polling mounted file until it reflects the new password...${NC}\n\n"
 
-ROTATED_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+ROTATED_PASS="${ROTATED_PASS:-$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)}"
 VOL_COUNT=0
 VOL_MAX=$MAX_VOLUME_POLLS
 while [ "$VOL_COUNT" -lt "$VOL_MAX" ]; do
@@ -608,25 +628,42 @@ box_blank 53 "$EMPH"
 box_bot 53 "$EMPH"
 printf "\n"
 
-APP_POD=$(require_app_pod)
-ROTATED_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
-ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+APP_POD=$(get_app_pod)
+ENV_PASS_NOW=$(get_env_password "$APP_POD")
+VOL_NOW=""
+if [ -n "$APP_POD" ]; then
+  VOL_NOW=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- cat /etc/secrets/password 2>/dev/null || echo '(pending)')
+fi
 
-VOL_NOW=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- cat /etc/secrets/password 2>/dev/null || echo '(pending)')
-box_top 50
-box_row 50 "  ${BOLD}K8s Secret:${NC}     ${ACCENT}${ROTATED_PASS}${NC}"
-box_row 50 "  ${BOLD}Volume mount:${NC}   ${ACCENT}${VOL_NOW}${NC}"
-box_mid 50
-box_row 50 "  ${BOLD}DB_PASSWORD:${NC}    ${ERR}${ENV_PASS}${NC}"
-box_bot 50
+# Prefer the snapshot from step 9 — Reloader often wins before we reach this step.
+STALE_ENV="${ENV_PASS_AT_ROTATION:-$BEFORE_PASS}"
+if [ -z "$STALE_ENV" ] || [ "$STALE_ENV" = "$ROTATED_PASS" ]; then
+  STALE_ENV="$BEFORE_PASS"
+fi
+
+box_top 54
+box_row 54 "  ${BOLD}K8s Secret (now):${NC}              ${ACCENT}${ROTATED_PASS}${NC}"
+box_row 54 "  ${BOLD}Volume mount (now):${NC}            ${ACCENT}${VOL_NOW}${NC}"
+box_mid 54
+box_row 54 "  ${BOLD}DB_PASSWORD at rotation:${NC}       ${ERR}${STALE_ENV}${NC}"
+if [ -n "$ENV_PASS_NOW" ] && [ "$ENV_PASS_NOW" != "$STALE_ENV" ]; then
+  box_row 54 "  ${BOLD}DB_PASSWORD in running pod now:${NC}  ${ACCENT}${ENV_PASS_NOW}${NC}"
+  box_row 54 "  ${DIM}(Reloader likely restarted the pod during step 10)${NC}"
+elif [ -n "$ENV_PASS_NOW" ] && [ "$ENV_PASS_NOW" = "$STALE_ENV" ]; then
+  box_row 54 "  ${BOLD}DB_PASSWORD in running pod now:${NC}  ${ERR}${ENV_PASS_NOW}${NC}  ${ERR}still stale${NC}"
+else
+  box_row 54 "  ${BOLD}DB_PASSWORD in running pod now:${NC}  ${DIM}(unavailable)${NC}"
+fi
+box_bot 54
 printf "\n"
 
-if [ "$ENV_PASS" != "$ROTATED_PASS" ]; then
-  status_warn "Env var is STALE — still holds the pre-rotation value"
-  printf "\n    ${BOLD}Solution:${NC} A ${BOLD}rolling restart${NC} refreshes env vars.\n"
-  printf "    ${DIM}Reloader automates this. Without it, we restart manually.${NC}\n"
+if [ "$STALE_ENV" != "$ROTATED_PASS" ]; then
+  status_warn "Env var was STALE right after rotation — still held ${STALE_ENV}"
+  printf "\n    ${BOLD}Solution:${NC} ${BOLD}Rolling restart${NC} (Stakater Reloader does this automatically).\n"
+  printf "    ${DIM}Step 12 shows the rollout / refreshed env.${NC}\n"
 else
-  status_ok "Env var already matches (Reloader may have restarted the pod)"
+  status_warn "Could not capture a stale env at rotation — use the BEFORE password for narrative"
+  printf "    ${DIM}Expected: DB_PASSWORD stayed ${BEFORE_PASS} while Secret became ${ROTATED_PASS}${NC}\n"
 fi
 pause
 
@@ -641,12 +678,21 @@ if [ -n "$RELOADER_RUNNING" ]; then
   printf "\n    ${DIM}Checking if Reloader already restarted the pod...${NC}\n\n"
 
   APP_POD=$(require_app_pod)
-  ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+  ENV_PASS=$(get_env_password "$APP_POD")
 
   if [ "$ENV_PASS" = "$ROTATED_PASS" ]; then
-    status_ok "Reloader already restarted the pod — env vars are current"
+    status_ok "Reloader restarted the pod — env vars are current"
     printf "\n"
     printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ACCENT}%s${NC}  ${ACCENT}✔${NC}\n" "$ENV_PASS"
+    if [ -n "${STALE_ENV:-}" ] && [ "$STALE_ENV" != "$ROTATED_PASS" ]; then
+      printf "    ${DIM}│${NC}  (was ${ERR}%s${NC} at rotation — step 11)${NC}\n" "$STALE_ENV"
+    fi
+    printf "\n    ${EMPH}Watch Reloader in k9s? [Y/n] ${NC}"
+    read -r k9s_reloader
+    case "${k9s_reloader:-n}" in
+      [yY]*) k9s -n "$NAMESPACE" ;;
+      *) ;;
+    esac
   else
     printf "    ${BOLD}Waiting for Reloader to restart the pod...${NC}\n\n"
     RESTART_COUNT=0
@@ -664,7 +710,7 @@ if [ -n "$RELOADER_RUNNING" ]; then
       fi
       if [ "$APP_POD" != "$OLD_POD" ]; then
         kubectl wait --for=condition=Ready pod -n "$NAMESPACE" "$APP_POD" --timeout=30s 2>/dev/null
-        ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+        ENV_PASS=$(get_env_password "$APP_POD")
         printf "    ${ACCENT}[%s]  ✔  Pod restarted by Reloader${NC}\n" "$TIMESTAMP"
         printf "\n"
         printf "    ${DIM}│${NC}  New pod:      ${BOLD}%s${NC}\n" "$APP_POD"
@@ -690,8 +736,9 @@ else
   box_bot 50
   printf "\n"
 
+  ENV_PASS=$(get_env_password "$(get_app_pod)")
   printf "    ${ERR}━━━ BEFORE restart ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ERR}%s${NC}  ${ERR}✘ stale${NC}\n\n" "$ENV_PASS"
+  printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ERR}%s${NC}  ${ERR}✘ stale${NC}\n\n" "${STALE_ENV:-$ENV_PASS}"
   pause
 
   printf "    ${BOLD}Triggering rolling restart...${NC}\n\n"
@@ -702,7 +749,7 @@ else
   APP_POD=$(require_app_pod)
   kubectl wait --for=condition=Ready pod -n "$NAMESPACE" "$APP_POD" --timeout=30s 2>/dev/null
 
-  FRESH_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+  FRESH_PASS=$(get_env_password "$APP_POD")
 
   printf "\n    ${ACCENT}━━━ AFTER restart ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
   printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ACCENT}%s${NC}  ${ACCENT}✔ current${NC}\n\n" "$FRESH_PASS"
@@ -723,7 +770,7 @@ box_row 56 "  ${BOLD}Optional second pass${NC} — ESO + decoded Secret:"
 box_blank 56
 box_row 56 "  ${ACCENT}:externalsecrets${NC}  sync status + LAST SYNC timer"
 box_row 56 "  ${ACCENT}:secrets${NC}          ${BOLD}x${NC} decode"
-box_row 56 "  (${ACCENT}:pods${NC} / ${ACCENT}:events${NC} were best ${BOLD}right after rotation${NC})"
+box_row 56 "  (${ACCENT}:pods${NC} / ${ACCENT}:events${NC} — best during step 12 / Reloader rollout)"
 box_blank 56
 box_row 56 "  ${BOLD}Pro tip:${NC} decode secret, rotate again in Priv Cloud"
 box_bot 56

--- a/demos/secrets_manager/k8s/eso-reloader/demo.sh
+++ b/demos/secrets_manager/k8s/eso-reloader/demo.sh
@@ -1,0 +1,784 @@
+#!/bin/bash
+# Auto-Rotate Kubernetes Secrets — ESO + CyberArk Conjur Cloud (~12–18 min; pacing is tunable)
+# Interactive walkthrough: press ENTER to advance between steps.
+set -euo pipefail
+
+# Force UTF-8 so bash's ${#var} and printf widths line up with what the terminal renders.
+# (Box drawing chars and em-dashes are multi-byte; without this they pad by bytes.)
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+# ── Palette: bright cyan + yellow (high contrast on dark terminals); red only for errors ──
+# $'…' so the variables hold real ESC bytes — works both inside printf format
+# strings and when passed as %s arguments to the box helpers below.
+ACCENT=$'\033[96m'   # bright cyan — frames, commands, primary highlights
+EMPH=$'\033[93m'     # bright yellow — prompts, step IDs, calls-to-action
+ERR=$'\033[91m'      # bright red — failures and stale/wrong values only
+BOLD=$'\033[1m'
+DIM=$'\033[2m'
+NC=$'\033[0m'
+
+NAMESPACE="eso-reloader"
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+SECRET_NAME="db-credentials"
+DEPLOYMENT="rotation-demo-app"
+
+# Poll cadence matches ESO refreshInterval (15s): checks align with sync cycles and ease API churn.
+# Faster rehearsal: export CYBR_ESO_DEMO_POLL_INTERVAL=5
+POLL_INTERVAL="${CYBR_ESO_DEMO_POLL_INTERVAL:-15}"
+# Iteration caps × POLL_INTERVAL ≈ max wall-clock per phase (tuned for default 15s).
+MAX_SECRET_POLLS=12   # rotation detect (~3 min)
+MAX_VOLUME_POLLS=8    # kubelet file sync (~2 min)
+MAX_RESTART_POLLS=8   # Reloader rollout (~2 min)
+
+pause() {
+  printf "\n${EMPH}    ▶ Press ENTER to continue...${NC}"
+  read -r
+  echo
+}
+
+# ── UTF-8-aware layout helpers ────────────────────────────────────────────────
+# All box content includes ANSI color escapes; we strip those before measuring,
+# then pad by visual columns instead of bytes so multi-byte chars (— ① ② ③ ▼ •)
+# don't shove the right border off-grid.
+
+# Strip ANSI CSI sequences (ESC[…letter) using pure bash — no fork per call.
+_strip_ansi() {
+  local s="$1" out="" i=0 n=${#1} esc=$'\033'
+  while (( i < n )); do
+    if [[ "${s:i:1}" == "$esc" && "${s:i+1:1}" == "[" ]]; then
+      i=$(( i + 2 ))
+      while (( i < n )) && [[ ! "${s:i:1}" =~ [a-zA-Z] ]]; do i=$(( i + 1 )); done
+      i=$(( i + 1 ))
+    else
+      out+="${s:i:1}"
+      i=$(( i + 1 ))
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# Visible width in columns (LC_ALL is forced to UTF-8 above).
+_vlen() {
+  local s
+  s=$(_strip_ansi "$1")
+  printf '%d' "${#s}"
+}
+
+# Right-pad a string to N visible columns with spaces.
+_vpad() {
+  local width="$1" s="$2" len pad
+  len=$(_vlen "$s")
+  pad=$(( width - len ))
+  (( pad < 0 )) && pad=0
+  printf '%s%*s' "$s" "$pad" ''
+}
+
+# Repeat a (possibly multi-byte) char N times — pure bash, multi-byte safe.
+_repeat() {
+  local ch="$1" n="$2" out="" i=0
+  while (( i < n )); do out+="$ch"; i=$(( i + 1 )); done
+  printf '%s' "$out"
+}
+
+# Box primitives. WIDTH is the visible width inside the bars, not counting them.
+# Optional second arg overrides border color (default ACCENT).
+box_top()   { local w="$1" c="${2:-$ACCENT}"; printf '    %s┌%s┐%s\n' "$c" "$(_repeat '─' "$w")" "$NC"; }
+box_mid()   { local w="$1" c="${2:-$ACCENT}"; printf '    %s├%s┤%s\n' "$c" "$(_repeat '─' "$w")" "$NC"; }
+box_bot()   { local w="$1" c="${2:-$ACCENT}"; printf '    %s└%s┘%s\n' "$c" "$(_repeat '─' "$w")" "$NC"; }
+box_blank() { local w="$1" c="${2:-$ACCENT}"; printf '    %s│%*s%s│%s\n' "$c" "$w" '' "$c" "$NC"; }
+
+# Render `│ <content padded to W visible cols> │`. Content may include ANSI escapes.
+# Usage: box_row WIDTH "  Some content"            — default ACCENT borders
+#        box_row WIDTH "  Some content" "$EMPH"    — custom border color
+box_row() {
+  local w="$1" content="$2" c="${3:-$ACCENT}" padded
+  padded=$(_vpad "$w" "$content")
+  printf '    %s│%s%s│%s\n' "$c" "$padded" "$c" "$NC"
+}
+
+header() {
+  local step="$1" title="$2" title_pad
+  title_pad=$(_vpad 46 "$title")
+  printf "\n"
+  printf "${ACCENT}  ╔══════════════════════════════════════════════════════╗${NC}\n"
+  printf "${ACCENT}  ║${NC} ${EMPH}%-6s${NC}${BOLD}%s${NC} ${ACCENT}║${NC}\n" "$step" "$title_pad"
+  printf "${ACCENT}  ╚══════════════════════════════════════════════════════╝${NC}\n"
+}
+
+run_cmd() {
+  printf "    ${ACCENT}\$ %s${NC}\n" "$*"
+  eval "$@" 2>&1 | while IFS= read -r line; do printf "    %s\n" "$line"; done
+}
+
+info_box() {
+  local label="$1"
+  local value="$2"
+  printf "    ${DIM}│${NC} ${BOLD}%-22s${NC} %s\n" "$label" "$value"
+}
+
+divider() {
+  printf "    ${DIM}├──────────────────────────────────────────────────${NC}\n"
+}
+
+status_ok() {
+  printf "    ${ACCENT}  ✔  %s${NC}\n" "$1"
+}
+
+status_warn() {
+  printf "    ${EMPH}  ⚠  %s${NC}\n" "$1"
+}
+
+status_fail() {
+  printf "    ${ERR}  ✘  %s${NC}\n" "$1"
+}
+
+if ! [[ "$POLL_INTERVAL" =~ ^[0-9]+$ ]] || [ "$POLL_INTERVAL" -lt 1 ]; then
+  printf "${EMPH}Warning:${NC} invalid CYBR_ESO_DEMO_POLL_INTERVAL=%s, defaulting to 15s.\n" "${POLL_INTERVAL:-unset}"
+  POLL_INTERVAL=15
+fi
+
+get_app_pod() {
+  kubectl get pods -n "$NAMESPACE" -l app="$DEPLOYMENT" --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true
+}
+
+require_app_pod() {
+  local pod
+  pod="$(get_app_pod)"
+  if [ -z "$pod" ]; then
+    status_fail "No running app pod found for app=$DEPLOYMENT in namespace $NAMESPACE"
+    return 1
+  fi
+  printf "%s" "$pod"
+}
+
+brand_bar() {
+  printf "${ACCENT}${BOLD}  %-54s${NC}\n" "  CyberArk Conjur Cloud · ESO · Reloader"
+}
+
+# ═══════════════════════════════════════════════════════════
+# TITLE SCREEN
+# ═══════════════════════════════════════════════════════════
+clear 2>/dev/null || true
+printf "\n"
+brand_bar
+printf "\n"
+printf "${ACCENT}"
+cat <<'LOGO'
+           ██████╗██╗   ██╗██████╗ ███████╗██████╗  █████╗ ██████╗ ██╗  ██╗
+          ██╔════╝╚██╗ ██╔╝██╔══██╗██╔════╝██╔══██╗██╔══██╗██╔══██╗██║ ██╔╝
+          ██║      ╚████╔╝ ██████╔╝█████╗  ██████╔╝███████║██████╔╝█████╔╝
+          ██║       ╚██╔╝  ██╔══██╗██╔══╝  ██╔══██╗██╔══██║██╔══██╗██╔═██╗
+          ╚██████╗   ██║   ██████╔╝███████╗██║  ██║██║  ██║██║  ██║██║  ██╗
+           ╚═════╝   ╚═╝   ╚═════╝ ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝
+LOGO
+printf "${NC}"
+printf "${EMPH}"
+cat <<'TITLE'
+      ╔═══════════════════════════════════════════════════════════════════╗
+      ║                                                                   ║
+      ║       █████╗ ██╗   ██╗████████╗ ██████╗                           ║
+      ║      ██╔══██╗██║   ██║╚══██╔══╝██╔═══██╗                          ║
+      ║      ███████║██║   ██║   ██║   ██║   ██║                          ║
+      ║      ██╔══██║██║   ██║   ██║   ██║   ██║                          ║
+      ║      ██║  ██║╚██████╔╝   ██║   ╚██████╔╝                          ║
+      ║      ╚═╝  ╚═╝ ╚═════╝    ╚═╝    ╚═════╝                           ║
+      ║                                                                   ║
+      ║      ██████╗  ██████╗ ████████╗ █████╗ ████████╗███████╗          ║
+      ║      ██╔══██╗██╔═══██╗╚══██╔══╝██╔══██╗╚══██╔══╝██╔════╝          ║
+      ║      ██████╔╝██║   ██║   ██║   ███████║   ██║   █████╗            ║
+      ║      ██╔══██╗██║   ██║   ██║   ██╔══██║   ██║   ██╔══╝            ║
+      ║      ██║  ██║╚██████╔╝   ██║   ██║  ██║   ██║   ███████╗          ║
+      ║      ╚═╝  ╚═╝ ╚═════╝    ╚═╝   ╚═╝  ╚═╝   ╚═╝   ╚══════╝          ║
+      ║                                                                   ║
+      ║          K U B E R N E T E S    S E C R E T S                     ║
+      ║                                                                   ║
+      ╚═══════════════════════════════════════════════════════════════════╝
+TITLE
+printf "${NC}\n"
+printf "    ${DIM}Powered by${NC}  ${ACCENT}${BOLD}CyberArk Conjur Cloud${NC}  ${DIM}+${NC}  ${ACCENT}${BOLD}External Secrets Operator${NC}\n"
+printf "    ${DIM}A${NC} ${EMPH}${BOLD}Palo Alto Networks${NC} ${DIM}company${NC}\n\n"
+
+printf "    ${BOLD}End-to-end secret rotation:${NC}\n\n"
+printf "      ${EMPH}Privilege Cloud${NC}  ──▶  ${ACCENT}Conjur Sync${NC}  ──▶  ${ACCENT}Conjur Cloud${NC}\n"
+printf "      ${DIM}(source of truth)${NC}\n"
+printf "                                ${DIM}│${NC}\n"
+printf "                                ▼\n"
+printf "                       ${ACCENT}ESO Controller${NC}    ${DIM}(JWT auth, 15s poll)${NC}\n"
+printf "                                ${DIM}│${NC}\n"
+printf "                                ▼\n"
+printf "                       ${EMPH}K8s Secret${NC}  ──▶  ${BOLD}Application Pod${NC}\n\n"
+printf "    ${BOLD}Two consumption methods:${NC}\n"
+printf "      ${ACCENT}① Volume Mount${NC}    ${DIM}── files update automatically${NC}\n"
+printf "      ${EMPH}② Env Variables${NC}   ${DIM}── requires pod restart${NC}\n"
+printf "\n"
+printf "    ${BOLD}Why both consumptions in one demo (same CyberArk path)?${NC}\n\n"
+printf "    ${DIM}•${NC} ${BOLD}Single integration:${NC} Privilege Cloud → Conjur → ESO → ${EMPH}one${NC} Kubernetes Secret (%s).\n" "$SECRET_NAME"
+printf "    ${DIM}    Reloader watches ${BOLD}that${NC} Secret — there is no second auth flow or second ExternalSecret.\n"
+printf "    ${DIM}•${NC} ${BOLD}Two Kubernetes semantics:${NC} secrets-as-${ACCENT}files${NC} update when kubelet syncs the volume; secrets-as-${EMPH}env${NC} are fixed at container start.\n"
+printf "    ${DIM}•${NC} ${BOLD}Talk-track goal:${NC} show real-world split (apps read files vs getenv at boot) under one rotation pipeline — and why Reloader closes the env-var gap after ESO updates the Secret.\n\n"
+printf "    ${DIM}(Tip:${NC} export ${ACCENT}CYBR_ESO_DEMO_POLL_INTERVAL${DIM}=5 for faster rehearsal polling.)${NC}\n\n"
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "1/13" "Demo Environment"
+# ═══════════════════════════════════════════════════════════
+printf "\n    ${DIM}All resources live in the${NC} ${ACCENT}${BOLD}%s${NC} ${DIM}namespace.${NC}\n\n" "$NAMESPACE"
+run_cmd kubectl get ns "$NAMESPACE"
+echo
+run_cmd kubectl get sa -n "$NAMESPACE" eso-reloader-sa
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "2/13" "ESO Controller"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+box_top 50
+box_row 50 "  ESO runs as a ${BOLD}cluster-wide controller${NC}."
+box_row 50 "  It watches for SecretStore and ExternalSecret"
+box_row 50 "  resources ${BOLD}across all namespaces${NC}."
+box_bot 50
+printf "\n"
+run_cmd kubectl get pods -n external-secrets
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "3/13" "SecretStore — Conjur JWT Authentication"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+printf "    ${BOLD}How ESO authenticates to CyberArk:${NC}\n\n"
+box_top 50
+box_blank 50
+box_row 50 "  ${BOLD}K8s ServiceAccount${NC}"
+box_row 50 "       ${DIM}│${NC}  ${DIM}mints JWT token${NC}"
+box_row 50 "       ▼"
+box_row 50 "  ${ACCENT}authn-jwt/zg-eso${NC}"
+box_row 50 "       ${DIM}│${NC}  ${DIM}validates signature via K8s OIDC${NC}"
+box_row 50 "       ▼"
+box_row 50 "  ${ACCENT}Conjur Cloud${NC}  ${DIM}returns access token${NC}"
+box_blank 50
+box_row 50 "  ${EMPH}Zero static API keys in the cluster${NC}"
+box_blank 50
+box_bot 50
+printf "\n"
+
+printf "    ${BOLD}SecretStore manifest:${NC}\n"
+run_cmd cat "$DEMO_DIR/secretstore.yaml"
+echo
+printf "    ${BOLD}SecretStore status:${NC}\n"
+run_cmd kubectl get secretstore -n "$NAMESPACE" conjur -o wide
+SS_READY=$(kubectl get secretstore -n "$NAMESPACE" conjur -o jsonpath='{.status.conditions[0].status}' 2>/dev/null || echo "")
+if [ "$SS_READY" = "True" ]; then
+  status_ok "SecretStore is Valid and Ready"
+else
+  status_fail "SecretStore is not ready — check Conjur connectivity"
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "4/13" "ExternalSecret — 15s Refresh Interval"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+printf "    ${BOLD}The refresh interval drives rotation detection:${NC}\n\n"
+box_top 50
+box_blank 50
+box_row 50 "  ${EMPH}${BOLD}refreshInterval: 15s${NC}"
+box_blank 50
+box_row 50 "  Every 15 seconds ESO:"
+box_row 50 "    ${ACCENT}①${NC} Re-authenticates to Conjur (JWT)"
+box_row 50 "    ${ACCENT}②${NC} Fetches current secret values"
+box_row 50 "    ${ACCENT}③${NC} Compares with existing K8s Secret"
+box_row 50 "    ${ACCENT}④${NC} Updates K8s Secret if values changed"
+box_blank 50
+box_bot 50
+printf "\n"
+
+printf "    ${BOLD}ExternalSecret manifest:${NC}\n"
+run_cmd cat "$DEMO_DIR/externalsecret.yaml"
+echo
+printf "    ${BOLD}Sync status:${NC}\n"
+run_cmd kubectl get externalsecret -n "$NAMESPACE" db-credentials -o wide
+ES_STATUS=$(kubectl get externalsecret -n "$NAMESPACE" db-credentials -o jsonpath='{.status.conditions[0].reason}' 2>/dev/null || echo "")
+if [ "$ES_STATUS" = "SecretSynced" ]; then
+  status_ok "ExternalSecret is syncing every 15 seconds"
+else
+  status_fail "ExternalSecret sync error: $ES_STATUS"
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "5/13" "Conjur Policy — Identity & Access"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+printf "    ${BOLD}Three policies wire up authorization in Conjur Cloud:${NC}\n\n"
+box_top 52
+box_row 52 "  ${ACCENT}①${NC} ${BOLD}Workload Host${NC}"
+box_row 52 "     Defines identity + JWT sub annotation"
+box_row 52 "                        ${DIM}│${NC}"
+box_row 52 "  ${ACCENT}②${NC} ${BOLD}Safe Access Grant${NC}"
+box_row 52 "     Adds host to k8s-eso/delegation/consumers"
+box_row 52 "                        ${DIM}│${NC}"
+box_row 52 "  ${ACCENT}③${NC} ${BOLD}Authenticator Grant${NC}"
+box_row 52 "     Allows host to use authn-jwt/zg-eso"
+box_bot 52
+printf "\n"
+for f in "$DEMO_DIR"/conjur-policy/*.yaml; do
+  printf "    ${EMPH}── %s ──${NC}\n" "$(basename "$f")"
+  while IFS= read -r line; do printf "    ${DIM}%s${NC}\n" "$line"; done < "$f"
+  echo
+done
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "6/13" "The K8s Secret — Current State"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+run_cmd kubectl get secret -n "$NAMESPACE" "$SECRET_NAME"
+
+CURR_USER=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.username}" | base64 --decode)
+CURR_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+
+printf "\n"
+box_top 37
+box_row 37 "  ${BOLD}Decoded Secret Values${NC}"
+box_mid 37
+box_row 37 "  username:  ${ACCENT}${CURR_USER}${NC}"
+box_row 37 "  password:  ${ACCENT}${CURR_PASS}${NC}"
+box_bot 37
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "7/13" "Application Pod — Two Consumption Methods"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+printf "    ${BOLD}The app consumes the same Kubernetes Secret (${SECRET_NAME}) TWO ways.${NC}\n"
+printf "    ${DIM}This is not two CyberArk or ESO integrations — one ESO sync feeds one Secret; we surface both consumption styles Kubernetes supports.${NC}\n\n"
+printf "    ${BOLD}Where each pattern is applicable${NC}\n\n"
+printf "    ${ACCENT}① Volume mount ${DIM}(/etc/secrets)${NC} — Use when the app reads ${BOLD}paths${NC}: JDBC/property files, PEM bundles, agents that watch directories.\n"
+printf "    ${DIM}    After ESO writes the Secret, kubelet refreshes mounted files — often ${BOLD}no restart${NC}.${NC}\n\n"
+printf "    ${EMPH}② Env vars ${DIM}(DB_USERNAME / DB_PASSWORD)${NC} — Use for ${BOLD}12-factor${NC} style apps and frameworks that call getenv() at startup.\n"
+printf "    ${DIM}    Values stay stale until a new container starts — ${BOLD}Reloader${NC} triggers that rollout when the Secret changes.${NC}\n\n"
+box_top 52
+box_blank 52
+box_row 52 "  ${ACCENT}┌─────────────────────┐${NC}  ${EMPH}┌─────────────────────┐${NC}"
+box_row 52 "  ${ACCENT}│${NC}  ${BOLD}① Volume Mount${NC}     ${ACCENT}│${NC}  ${EMPH}│${NC}  ${BOLD}② Env Variables${NC}    ${EMPH}│${NC}"
+box_row 52 "  ${ACCENT}│${NC}  /etc/secrets/      ${ACCENT}│${NC}  ${EMPH}│${NC}  DB_USERNAME        ${EMPH}│${NC}"
+box_row 52 "  ${ACCENT}│${NC}                     ${ACCENT}│${NC}  ${EMPH}│${NC}  DB_PASSWORD        ${EMPH}│${NC}"
+box_row 52 "  ${ACCENT}│${NC}  Updates: ${ACCENT}AUTO${NC}      ${ACCENT}│${NC}  ${EMPH}│${NC}  Updates: ${ERR}ON RESTART${NC}${EMPH}│${NC}"
+box_row 52 "  ${ACCENT}│${NC}  Delay:   ~60-90s   ${ACCENT}│${NC}  ${EMPH}│${NC}  Delay:   pod cycle ${EMPH}│${NC}"
+box_row 52 "  ${ACCENT}│${NC}  App change: ${ACCENT}NONE${NC}   ${ACCENT}│${NC}  ${EMPH}│${NC}  App change: ${ACCENT}NONE${NC}   ${EMPH}│${NC}"
+box_row 52 "  ${ACCENT}└─────────────────────┘${NC}  ${EMPH}└─────────────────────┘${NC}"
+box_blank 52
+box_bot 52
+printf "\n"
+
+APP_POD=$(require_app_pod)
+
+printf "    ${ACCENT}━━━ ① Volume Mount ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n\n"
+run_cmd kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- ls -la /etc/secrets/
+echo
+VOL_USER=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- cat /etc/secrets/username 2>/dev/null || echo "")
+VOL_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- cat /etc/secrets/password 2>/dev/null || echo "")
+printf "    ${DIM}│${NC}  /etc/secrets/username:  ${ACCENT}%s${NC}\n" "$VOL_USER"
+printf "    ${DIM}│${NC}  /etc/secrets/password:  ${ACCENT}%s${NC}\n" "$VOL_PASS"
+pause
+
+printf "    ${EMPH}━━━ ② Environment Variables ━━━━━━━━━━━━━━━━━━━━━━${NC}\n\n"
+ENV_USER=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_USERNAME 2>/dev/null || echo "")
+ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+printf "    ${DIM}│${NC}  DB_USERNAME:  ${EMPH}%s${NC}\n" "$ENV_USER"
+printf "    ${DIM}│${NC}  DB_PASSWORD:  ${EMPH}%s${NC}\n" "$ENV_PASS"
+printf "\n"
+if [ "$VOL_PASS" = "$ENV_PASS" ]; then
+  status_ok "Both methods show the same value — the secret is in sync"
+else
+  status_warn "Values differ — env vars are frozen at pod start; volume mounts track the K8s Secret"
+  printf "    ${DIM}│${NC}  Volume mount:  ${ACCENT}%s${NC}\n" "$VOL_PASS"
+  printf "    ${DIM}│${NC}  Env var:       ${EMPH}%s${NC}\n" "$ENV_PASS"
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "8/13" "Reloader — Auto Pod Restart on Secret Change"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+box_top 52
+box_row 52 "  ${BOLD}Stakater Reloader${NC} watches K8s Secrets."
+box_blank 52
+box_row 52 "  When ${BOLD}db-credentials${NC} updates, Reloader triggers"
+box_row 52 "  a rolling restart on Deployments with:"
+box_blank 52
+box_row 52 "    ${ACCENT}reloader.stakater.com/auto: \"true\"${NC}"
+box_blank 52
+box_row 52 "  This closes the env var gap automatically."
+box_bot 52
+printf "\n"
+
+RELOADER_POD=$(kubectl get pods -A -l app.kubernetes.io/name=reloader -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [ -n "$RELOADER_POD" ]; then
+  status_ok "Reloader is installed and running"
+  echo
+  run_cmd kubectl get pods -A -l app.kubernetes.io/name=reloader
+else
+  status_warn "Reloader not installed — will demo manual restart"
+  printf "\n    ${DIM}Install later:${NC}\n"
+  printf "    ${DIM}  helm repo add stakater https://stakater.github.io/stakater-charts${NC}\n"
+  printf "    ${DIM}  helm install reloader stakater/reloader -n reloader --create-namespace${NC}\n"
+fi
+echo
+printf "    ${BOLD}Deployment annotation:${NC}\n"
+ANNOT=$(kubectl get deployment -n "$NAMESPACE" "$DEPLOYMENT" -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}' 2>/dev/null || echo "")
+if [ "$ANNOT" = "true" ]; then
+  printf "    ${DIM}│${NC}  reloader.stakater.com/auto: ${ACCENT}\"true\"${NC}\n"
+else
+  printf "    ${DIM}│${NC}  reloader.stakater.com/auto: ${DIM}(not set)${NC}\n"
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+# LIVE ROTATION BANNER
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+brand_bar
+printf "\n"
+printf "${EMPH}"
+cat <<'ROTATION_BANNER'
+    ╔═══════════════════════════════════════════════════════╗
+    ║                                                       ║
+    ║               L I V E   R O T A T I O N               ║
+    ║                                                       ║
+    ║       Privilege Cloud password change triggers:       ║
+    ║     K8s Secret update -> Reloader rollout -> app      ║
+    ║                                                       ║
+    ╚═══════════════════════════════════════════════════════╝
+ROTATION_BANNER
+printf "${NC}\n"
+
+# ═══════════════════════════════════════════════════════════
+header "9/13" "Live Auto-Rotation — K8s Secret"
+# ═══════════════════════════════════════════════════════════
+
+BEFORE_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+BEFORE_USER=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.username}" | base64 --decode)
+
+printf "\n"
+box_top 41
+box_row 41 "  ${BOLD}Current K8s Secret${NC}"
+box_mid 41
+box_row 41 "  username:          ${BOLD}${BEFORE_USER}${NC}"
+box_row 41 "  password:          ${BOLD}${BEFORE_PASS}${NC}"
+box_row 41 "  refresh interval:  ${ACCENT}15s${NC}"
+box_bot 41
+
+printf "\n"
+box_top 53 "$EMPH"
+box_blank 53 "$EMPH"
+box_row 53 "  ${BOLD}ACTION REQUIRED:${NC}" "$EMPH"
+box_blank 53 "$EMPH"
+box_row 53 "  Go to ${EMPH}${BOLD}Privilege Cloud${NC} and change the password" "$EMPH"
+box_row 53 "  for ${BOLD}account-ssh-user-1${NC} in the ${BOLD}k8s-eso${NC} safe." "$EMPH"
+box_blank 53 "$EMPH"
+box_row 53 "  ESO will detect the change on its next sync" "$EMPH"
+box_row 53 "  cycle (${ACCENT}≤15 seconds${NC})." "$EMPH"
+box_blank 53 "$EMPH"
+box_bot 53 "$EMPH"
+
+printf "\n${EMPH}    ▶ Change the password in Privilege Cloud, then press ENTER...${NC}"
+read -r
+
+printf "\n    ${BOLD}Watching K8s Secret for rotation...${NC}\n\n"
+POLL_COUNT=0
+MAX_POLLS=$MAX_SECRET_POLLS
+while [ "$POLL_COUNT" -lt "$MAX_POLLS" ]; do
+  CURRENT_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+  POLL_COUNT=$((POLL_COUNT + 1))
+  TIMESTAMP=$(date +"%H:%M:%S")
+
+  if [ "$CURRENT_PASS" != "$BEFORE_PASS" ]; then
+    printf "    ${ACCENT}[%s]  ✔  ROTATED${NC}\n" "$TIMESTAMP"
+    printf "\n"
+    box_top 47
+    box_row 47 "  ${ERR}Before:${NC}  ${BEFORE_PASS}"
+    box_row 47 "  ${ACCENT}After:${NC}   ${CURRENT_PASS}"
+    box_bot 47
+    printf "\n"
+    status_ok "K8s Secret auto-rotated"
+    status_ok "Zero code changes, zero manual intervention"
+    break
+  fi
+
+  REMAINING=$(( (MAX_POLLS - POLL_COUNT) * POLL_INTERVAL ))
+  printf "    ${DIM}[%s]${NC}  ${ACCENT}◌${NC}  polling... ${DIM}(%d/%d, ~%ds left)${NC}\n" "$TIMESTAMP" "$POLL_COUNT" "$MAX_POLLS" "$REMAINING"
+  sleep "$POLL_INTERVAL"
+done
+
+if [ "$POLL_COUNT" -eq "$MAX_POLLS" ]; then
+  status_fail "Timed out waiting for Secret update"
+  printf "    ${DIM}1. Password changed in Privilege Cloud?${NC}\n"
+  printf "    ${DIM}2. Conjur Sync replicated the change?${NC}\n"
+  printf "    ${DIM}3. kubectl get externalsecret -n %s db-credentials${NC}\n" "$NAMESPACE"
+fi
+
+# Jump to k9s right after the Secret changes so the audience can watch Reloader roll the
+# deployment before the scripted kubelet/env waits (those can take minutes).
+ROTATED_PASS_CHECK=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+if [ "$ROTATED_PASS_CHECK" != "$BEFORE_PASS" ]; then
+  printf "\n    ${BOLD}Reloader reacts to this Secret change next.${NC}\n"
+  printf "    ${DIM}Live view: ${BOLD}:pods${DIM} — new pod name / age (clearest for Reloader). ${BOLD}:events${DIM} — Scheduled/Pulled/Started (optional, noisier).${NC}\n\n"
+  printf "    ${EMPH}Open k9s now to watch the rollout? [Y/n] ${NC}"
+  read -r k9s_early
+  case "${k9s_early:-y}" in
+    [nN]*) ;;
+    *) k9s -n "$NAMESPACE" ;;
+  esac
+fi
+
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "10/13" "Method ① — Volume Mount Auto-Update"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+box_top 53
+box_blank 53
+box_row 53 "  Volume mounts are updated by ${BOLD}kubelet${NC} when the"
+box_row 53 "  K8s Secret changes. Propagation: ${BOLD}~60-90 seconds${NC}."
+box_blank 53
+box_row 53 "  No pod restart needed. No application changes."
+box_blank 53
+box_bot 53
+printf "\n"
+
+printf "    ${BOLD}Polling mounted file until it reflects the new password...${NC}\n\n"
+
+ROTATED_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+VOL_COUNT=0
+VOL_MAX=$MAX_VOLUME_POLLS
+while [ "$VOL_COUNT" -lt "$VOL_MAX" ]; do
+  APP_POD=$(get_app_pod)
+  VOL_COUNT=$((VOL_COUNT + 1))
+  TIMESTAMP=$(date +"%H:%M:%S")
+
+  if [ -z "$APP_POD" ]; then
+    REMAINING=$(( (VOL_MAX - VOL_COUNT) * POLL_INTERVAL ))
+    printf "    ${DIM}[%s]${NC}  ${ACCENT}◌${NC}  waiting for running app pod... ${DIM}(%d/%d, ~%ds)${NC}\n" "$TIMESTAMP" "$VOL_COUNT" "$VOL_MAX" "$REMAINING"
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+
+  VOL_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- cat /etc/secrets/password 2>/dev/null || echo "")
+
+  if [ "$VOL_PASS" = "$ROTATED_PASS" ]; then
+    printf "    ${ACCENT}[%s]  ✔  Volume mount updated!${NC}\n" "$TIMESTAMP"
+    printf "\n"
+    box_top 47
+    box_row 47 "  ${BOLD}Mounted file:${NC}  ${ACCENT}${VOL_PASS}${NC}"
+    box_row 47 "  ${BOLD}K8s Secret:${NC}    ${ACCENT}${ROTATED_PASS}${NC}"
+    box_bot 47
+    printf "\n"
+    status_ok "Volume mount matches K8s Secret"
+    status_ok "Kubelet propagated the change — zero restarts"
+    break
+  fi
+
+  REMAINING=$(( (VOL_MAX - VOL_COUNT) * POLL_INTERVAL ))
+  printf "    ${DIM}[%s]${NC}  ${ACCENT}◌${NC}  kubelet propagating... mounted=${DIM}%s${NC} ${DIM}(%d/%d, ~%ds)${NC}\n" "$TIMESTAMP" "$VOL_PASS" "$VOL_COUNT" "$VOL_MAX" "$REMAINING"
+  sleep "$POLL_INTERVAL"
+done
+
+if [ "$VOL_COUNT" -eq "$VOL_MAX" ]; then
+  status_warn "Kubelet hasn't propagated yet (volume poll limit reached)"
+  printf "    ${DIM}Re-check pods: kubectl get pods -n %s -l app=%s${NC}\n" "$NAMESPACE" "$DEPLOYMENT"
+  printf "    ${DIM}Then exec:     kubectl exec -n %s <pod> -c app -- cat /etc/secrets/password${NC}\n" "$NAMESPACE"
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "11/13" "Method ② — Env Variables (The Stale Problem)"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+box_top 53 "$EMPH"
+box_blank 53 "$EMPH"
+box_row 53 "  Environment variables are ${BOLD}frozen at pod startup${NC}." "$EMPH"
+box_row 53 "  They still hold the ${ERR}OLD${NC} password even though" "$EMPH"
+box_row 53 "  the K8s Secret already changed." "$EMPH"
+box_blank 53 "$EMPH"
+box_row 53 "  This is ${BOLD}standard Kubernetes behavior${NC}." "$EMPH"
+box_blank 53 "$EMPH"
+box_bot 53 "$EMPH"
+printf "\n"
+
+APP_POD=$(require_app_pod)
+ROTATED_PASS=$(kubectl get secret -n "$NAMESPACE" "$SECRET_NAME" -o jsonpath="{.data.password}" | base64 --decode)
+ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+
+VOL_NOW=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- cat /etc/secrets/password 2>/dev/null || echo '(pending)')
+box_top 50
+box_row 50 "  ${BOLD}K8s Secret:${NC}     ${ACCENT}${ROTATED_PASS}${NC}"
+box_row 50 "  ${BOLD}Volume mount:${NC}   ${ACCENT}${VOL_NOW}${NC}"
+box_mid 50
+box_row 50 "  ${BOLD}DB_PASSWORD:${NC}    ${ERR}${ENV_PASS}${NC}"
+box_bot 50
+printf "\n"
+
+if [ "$ENV_PASS" != "$ROTATED_PASS" ]; then
+  status_warn "Env var is STALE — still holds the pre-rotation value"
+  printf "\n    ${BOLD}Solution:${NC} A ${BOLD}rolling restart${NC} refreshes env vars.\n"
+  printf "    ${DIM}Reloader automates this. Without it, we restart manually.${NC}\n"
+else
+  status_ok "Env var already matches (Reloader may have restarted the pod)"
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "12/13" "Rolling Restart — Env Vars Refreshed"
+# ═══════════════════════════════════════════════════════════
+
+RELOADER_RUNNING=$(kubectl get pods -A -l app.kubernetes.io/name=reloader -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+if [ -n "$RELOADER_RUNNING" ]; then
+  printf "\n"
+  status_ok "Reloader is installed"
+  printf "\n    ${DIM}Checking if Reloader already restarted the pod...${NC}\n\n"
+
+  APP_POD=$(require_app_pod)
+  ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+
+  if [ "$ENV_PASS" = "$ROTATED_PASS" ]; then
+    status_ok "Reloader already restarted the pod — env vars are current"
+    printf "\n"
+    printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ACCENT}%s${NC}  ${ACCENT}✔${NC}\n" "$ENV_PASS"
+  else
+    printf "    ${BOLD}Waiting for Reloader to restart the pod...${NC}\n\n"
+    RESTART_COUNT=0
+    RESTART_MAX=$MAX_RESTART_POLLS
+    RESTART_DETECTED=0
+    OLD_POD="$APP_POD"
+    while [ "$RESTART_COUNT" -lt "$RESTART_MAX" ]; do
+      APP_POD=$(get_app_pod)
+      RESTART_COUNT=$((RESTART_COUNT + 1))
+      TIMESTAMP=$(date +"%H:%M:%S")
+      if [ -z "$APP_POD" ]; then
+        printf "    ${DIM}[%s]${NC}  ${ACCENT}◌${NC}  waiting for new app pod scheduling... ${DIM}(%d/%d)${NC}\n" "$TIMESTAMP" "$RESTART_COUNT" "$RESTART_MAX"
+        sleep "$POLL_INTERVAL"
+        continue
+      fi
+      if [ "$APP_POD" != "$OLD_POD" ]; then
+        kubectl wait --for=condition=Ready pod -n "$NAMESPACE" "$APP_POD" --timeout=30s 2>/dev/null
+        ENV_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+        printf "    ${ACCENT}[%s]  ✔  Pod restarted by Reloader${NC}\n" "$TIMESTAMP"
+        printf "\n"
+        printf "    ${DIM}│${NC}  New pod:      ${BOLD}%s${NC}\n" "$APP_POD"
+        printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ACCENT}%s${NC}\n" "$ENV_PASS"
+        RESTART_DETECTED=1
+        break
+      fi
+      printf "    ${DIM}[%s]${NC}  ${ACCENT}◌${NC}  waiting for Reloader... ${DIM}(%d/%d)${NC}\n" "$TIMESTAMP" "$RESTART_COUNT" "$RESTART_MAX"
+      sleep "$POLL_INTERVAL"
+    done
+    if [ "$RESTART_DETECTED" -eq 0 ]; then
+      status_warn "Did not observe pod replacement in the Reloader wait window"
+      printf "    ${DIM}Check: kubectl get pods -n %s -l app=%s${NC}\n" "$NAMESPACE" "$DEPLOYMENT"
+      printf "    ${DIM}Check: kubectl get events -n %s --sort-by=.lastTimestamp | tail -20${NC}\n" "$NAMESPACE"
+    fi
+  fi
+else
+  printf "\n"
+  box_top 50
+  box_row 50 "  Reloader is not installed. Performing a"
+  box_row 50 "  ${BOLD}manual rolling restart${NC} to demonstrate that"
+  box_row 50 "  env vars pick up the new password."
+  box_bot 50
+  printf "\n"
+
+  printf "    ${ERR}━━━ BEFORE restart ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+  printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ERR}%s${NC}  ${ERR}✘ stale${NC}\n\n" "$ENV_PASS"
+  pause
+
+  printf "    ${BOLD}Triggering rolling restart...${NC}\n\n"
+  run_cmd kubectl rollout restart deployment -n "$NAMESPACE" "$DEPLOYMENT"
+  printf "\n    ${DIM}Waiting for new pod to be ready...${NC}\n"
+  kubectl rollout status deployment -n "$NAMESPACE" "$DEPLOYMENT" --timeout=60s 2>&1 | while IFS= read -r line; do printf "    ${DIM}%s${NC}\n" "$line"; done
+
+  APP_POD=$(require_app_pod)
+  kubectl wait --for=condition=Ready pod -n "$NAMESPACE" "$APP_POD" --timeout=30s 2>/dev/null
+
+  FRESH_PASS=$(kubectl exec -n "$NAMESPACE" "$APP_POD" -c app -- printenv DB_PASSWORD 2>/dev/null || echo "")
+
+  printf "\n    ${ACCENT}━━━ AFTER restart ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+  printf "    ${DIM}│${NC}  DB_PASSWORD:  ${ACCENT}%s${NC}  ${ACCENT}✔ current${NC}\n\n" "$FRESH_PASS"
+
+  if [ "$FRESH_PASS" = "$ROTATED_PASS" ]; then
+    status_ok "Env var now matches the rotated password"
+    printf "\n    ${DIM}With Reloader installed, this restart happens automatically.${NC}\n"
+  fi
+fi
+pause
+
+# ═══════════════════════════════════════════════════════════
+header "13/13" "k9s — ExternalSecrets / Secrets"
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+box_top 56
+box_row 56 "  ${BOLD}Optional second pass${NC} — ESO + decoded Secret:"
+box_blank 56
+box_row 56 "  ${ACCENT}:externalsecrets${NC}  sync status + LAST SYNC timer"
+box_row 56 "  ${ACCENT}:secrets${NC}          ${BOLD}x${NC} decode"
+box_row 56 "  (${ACCENT}:pods${NC} / ${ACCENT}:events${NC} were best ${BOLD}right after rotation${NC})"
+box_blank 56
+box_row 56 "  ${BOLD}Pro tip:${NC} decode secret, rotate again in Priv Cloud"
+box_bot 56
+printf "\n"
+
+printf "    Launch k9s? [Y/n] "
+read -r answer
+case "${answer:-y}" in
+  [nN]*) ;;
+  *) k9s -n "$NAMESPACE" ;;
+esac
+
+# ═══════════════════════════════════════════════════════════
+# SUMMARY
+# ═══════════════════════════════════════════════════════════
+printf "\n"
+brand_bar
+printf "\n"
+printf "${ACCENT}"
+cat <<'COMPLETE_BANNER'
+    ╔═══════════════════════════════════════════════════════╗
+    ║                                                       ║
+    ║     ██████╗  ██████╗ ███╗   ██╗███████╗██╗            ║
+    ║     ██╔══██╗██╔═══██╗████╗  ██║██╔════╝██║            ║
+    ║     ██║  ██║██║   ██║██╔██╗ ██║█████╗  ██║            ║
+    ║     ██║  ██║██║   ██║██║╚██╗██║██╔══╝  ╚═╝            ║
+    ║     ██████╔╝╚██████╔╝██║ ╚████║███████╗██╗            ║
+    ║     ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚═╝            ║
+    ║                                                       ║
+    ╚═══════════════════════════════════════════════════════╝
+COMPLETE_BANNER
+printf "${NC}\n"
+
+printf "    ${BOLD}What we demonstrated:${NC}\n\n"
+printf "    ${ACCENT}  ✔${NC}  ESO with ${BOLD}15-second refresh interval${NC}\n"
+printf "    ${ACCENT}  ✔${NC}  SecretStore with ${BOLD}Conjur Cloud JWT authentication${NC}\n"
+printf "    ${ACCENT}  ✔${NC}  ExternalSecret pulling live credentials\n"
+printf "    ${ACCENT}  ✔${NC}  K8s Secret ${BOLD}auto-updated${NC} on password rotation\n"
+printf "    ${ACCENT}  ✔${NC}  ${ACCENT}Volume mounts${NC} updated automatically by kubelet\n"
+printf "    ${ACCENT}  ✔${NC}  ${EMPH}Env vars${NC} refreshed via rolling restart\n"
+printf "    ${ACCENT}  ✔${NC}  Full rotation: ${EMPH}Priv Cloud${NC} → ${ACCENT}Sync${NC} → ${ACCENT}Conjur${NC} → ${ACCENT}ESO${NC} → ${EMPH}K8s${NC} → ${BOLD}App${NC}\n"
+
+printf "\n"
+box_top 54
+box_row 54 "  ${BOLD}CyberArk Value:${NC}"
+box_blank 54
+box_row 54 "  ${DIM}•${NC} Privilege Cloud is the ${BOLD}single source of truth${NC}"
+box_row 54 "  ${DIM}•${NC} CPM rotation policies drive the schedule"
+box_row 54 "  ${DIM}•${NC} Conjur Sync replicates automatically"
+box_row 54 "  ${DIM}•${NC} ${BOLD}JWT auth${NC} — no static API keys in cluster"
+box_row 54 "  ${DIM}•${NC} ${BOLD}Policy-as-code${NC} — auditable YAML grants"
+box_row 54 "  ${DIM}•${NC} ESO is open-source — zero vendor lock-in"
+box_row 54 "  ${DIM}•${NC} Rotation is ${BOLD}transparent to the application${NC}"
+box_blank 54
+box_bot 54
+printf "\n"
+brand_bar
+printf "\n"

--- a/demos/secrets_manager/k8s/eso-reloader/demo_setup.md
+++ b/demos/secrets_manager/k8s/eso-reloader/demo_setup.md
@@ -1,0 +1,117 @@
+# Auto-Rotate Kubernetes Secrets — Demo Setup
+
+ESO polls CyberArk Conjur Cloud on a 15-second refresh interval and updates a native K8s Secret whenever the upstream password changes in Privilege Cloud. A sample application consumes the secret via volume mount and environment variables. Stakater Reloader triggers automatic pod restarts so environment variables always reflect the current credentials.
+
+## Main Entry Point
+
+```bash
+bash demos/secrets_manager/k8s/eso-reloader/setup.sh
+```
+
+Then run the interactive demo:
+
+```bash
+bash demos/secrets_manager/k8s/eso-reloader/demo.sh
+```
+
+## Deployment Context
+
+This demo runs on any Kubernetes cluster with outbound HTTPS to CyberArk Cloud. It reuses the same `authn-jwt/zg-eso` authenticator as the existing ESO demo but creates its own namespace, service account, safe, and host identity.
+
+ESO must be installed cluster-wide (the setup script handles this if missing). The lab uses a single-node k3s cluster registered to Rancher.
+
+The demo relies on shared tenant configuration from `demos/tenant_vars.sh` and helper functions from `demos/setup_env.sh`. `CYBR_DEMOS_PATH` must be set.
+
+## Required Environment
+
+| Requirement | Detail |
+|---|---|
+| `CYBR_DEMOS_PATH` | Repo root path |
+| `demos/tenant_vars.sh` | `TENANT_ID`, `TENANT_SUBDOMAIN`, `CLIENT_ID`, `CLIENT_SECRET` |
+| CyberArk tenant | Privilege Cloud, Conjur Cloud, ISPSS |
+| Conjur JWT authenticator | `authn-jwt/zg-eso` configured with K8s OIDC as token source |
+| Privilege Cloud safe | `k8s-eso` (shared with the existing ESO demo) with Conjur Sync as a member |
+| Kubernetes cluster | kubectl context set, Helm available |
+| k9s (optional) | For visual dashboard exploration |
+
+## Relationship to the Existing ESO Demo
+
+This demo shares the `authn-jwt/zg-eso` JWT authenticator with the existing `eso/` demo, and both use **the same** `refreshInterval: 15s` on the ExternalSecret. The differences:
+
+| | `eso/` | `eso-reloader/` |
+|---|---|---|
+| Namespace | `external-secrets` | `eso-reloader` |
+| Safe | `k8s-eso` | `k8s-eso` (shared) |
+| Sample app | None | `rotation-demo-app` with volume + env consumption |
+| Reloader | Not used | Auto pod restart on secret change |
+| Focus | General ESO + Conjur walkthrough | Auto-rotation + env var refresh story |
+
+## Setup Flow
+
+### 1. Privilege Cloud Safe
+
+This demo reuses the `k8s-eso` safe from the existing ESO demo. If you already ran the `eso/` demo, the safe, account, and Conjur Sync replication are already in place.
+
+If not, create the safe following the steps in `eso/demo_setup.md`.
+
+### 2. Run setup.sh
+
+`setup.sh` performs the following:
+
+1. Verifies ESO is installed cluster-wide (installs via Helm if missing).
+2. Creates the `eso-reloader` namespace.
+3. Creates the `eso-reloader-sa` service account.
+4. Applies three Conjur policies (workload host, safe access, authenticator grant).
+5. Applies the SecretStore (Conjur JWT auth) and ExternalSecret (15s refresh).
+6. Deploys `rotation-demo-app` (consumes secrets via volume mount + env vars).
+7. Installs Stakater Reloader if not present (auto pod restart on secret change).
+
+### 3. Manual Policy Application (if needed)
+
+If tenant credentials are not set in the environment, apply policies manually:
+
+```bash
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+identity_token=$(get_identity_token "$TENANT_ID" "$CLIENT_ID" "$CLIENT_SECRET")
+conjur_token=$(get_conjur_token "$TENANT_SUBDOMAIN" "$identity_token")
+
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+  "$(cat demos/secrets_manager/k8s/eso-reloader/conjur-policy/1-workload.yaml)"
+
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+  "$(cat demos/secrets_manager/k8s/eso-reloader/conjur-policy/2-grant-safe-access.yaml)"
+
+apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "conjur/authn-jwt" \
+  "$(cat demos/secrets_manager/k8s/eso-reloader/conjur-policy/3-grant-authenticator-access.yaml)"
+```
+
+## What Gets Deployed
+
+| Resource | Kind | Namespace | Purpose |
+|---|---|---|---|
+| `eso-reloader` | Namespace | — | Isolated demo namespace |
+| `eso-reloader-sa` | ServiceAccount | `eso-reloader` | JWT identity for Conjur auth |
+| `conjur` | SecretStore | `eso-reloader` | Conjur Cloud connection + JWT auth config |
+| `db-credentials` | ExternalSecret | `eso-reloader` | Declares Conjur variables + 15s refresh |
+| `db-credentials` | Secret | `eso-reloader` | K8s Secret created and maintained by ESO |
+| `rotation-demo-app` | Deployment | `eso-reloader` | Sample app with volume mount + env vars |
+| `reloader` | Deployment | `reloader` | Watches secrets, triggers pod rolling restarts |
+
+## Cleanup
+
+```bash
+bash demos/secrets_manager/k8s/eso-reloader/remove.sh
+```
+
+This removes all demo-specific K8s resources. ESO and Reloader are left installed as shared infrastructure. Conjur policies are not removed automatically.
+
+## Troubleshooting Setup
+
+| Symptom | Check |
+|---|---|
+| `no matches for kind "SecretStore"` | ESO CRDs not installed — `setup.sh` should handle this |
+| Webhook connection refused | ESO pods not ready — `kubectl rollout status` the ESO deployments |
+| `policy_invalid` — group not found | Conjur Sync not added to the Privilege Cloud safe |
+| Identity token `access_denied` | Verify `CLIENT_ID` suffix matches tenant |
+| 401 on ExternalSecret sync | Check the host is in `authn-jwt/zg-eso/apps` and `identity-path` matches |
+| Deployment timeout | Check ESO logs: `kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=50` |

--- a/demos/secrets_manager/k8s/eso-reloader/demo_validation.md
+++ b/demos/secrets_manager/k8s/eso-reloader/demo_validation.md
@@ -1,0 +1,288 @@
+# Auto-Rotate Kubernetes Secrets — Demo Validation
+
+ESO polls CyberArk Conjur Cloud every 15 seconds and updates a native K8s Secret when the upstream password changes. The sample application consumes the secret two ways: volume mount (auto-updates) and environment variables (Reloader triggers pod restart).
+
+## Start Here
+
+Confirm your kubectl context and the demo namespace:
+
+```bash
+kubectl config current-context
+kubectl get ns eso-reloader
+```
+
+All demo resources live in the `eso-reloader` namespace. ESO controller pods run in `external-secrets`. Reloader runs in `reloader`.
+
+## About
+
+| Component | Role |
+|---|---|
+| **Privilege Cloud** | Source of truth — safes, accounts, passwords, CPM rotation policies |
+| **Conjur Synchronizer** | Replicates Privilege Cloud safes and accounts into Conjur Cloud variables |
+| **Conjur Cloud** | Secrets manager — JWT authentication, policy-based access control, API retrieval |
+| **External Secrets Operator** | K8s controller — watches ExternalSecret CRs, authenticates to Conjur, writes K8s Secrets |
+| **K8s ServiceAccount** | Workload identity — JWT token is the authentication credential |
+| **Stakater Reloader** | Watches K8s Secrets for changes, triggers rolling restart on annotated Deployments |
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph cyberark["CyberArk Cloud"]
+        direction LR
+        subgraph pc["Privilege Cloud"]
+            safe["Safe: k8s-eso\nAccount: ssh-user-1\nCPM rotation policy"]
+        end
+        subgraph cc["Conjur Cloud"]
+            authn["authn-jwt/zg-eso\nidentity-path: data/poc-workloads"]
+            host["Host: ...eso-reloader-sa\nGrant: k8s-eso/delegation/consumers"]
+        end
+        pc -- "Conjur Sync" --> cc
+    end
+
+    subgraph k8s["Kubernetes Cluster"]
+        subgraph eso_ns["external-secrets namespace"]
+            eso["ESO Controller"]
+        end
+        subgraph demo_ns["eso-reloader namespace"]
+            ss["SecretStore — JWT auth to Conjur"]
+            es["ExternalSecret — 15s refresh"]
+            sa["ServiceAccount: eso-reloader-sa"]
+            secret["K8s Secret: db-credentials"]
+            app["rotation-demo-app\n(volume + env vars)"]
+        end
+        subgraph reloader_ns["reloader namespace"]
+            reloader["Stakater Reloader"]
+        end
+        eso -- "reconcile" --> es
+        es -- "creates / updates" --> secret
+        secret -- "volume mount\n(auto-update)" --> app
+        secret -- "env vars\n(frozen at start)" --> app
+        reloader -- "detect change\n→ rolling restart" --> app
+    end
+
+    cc -- "REST API\n(JWT auth)" --> eso
+```
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    participant PC as Privilege Cloud
+    participant CS as Conjur Synchronizer
+    participant CC as Conjur Cloud
+    participant ESO as ESO Controller
+    participant SA as K8s ServiceAccount
+    participant KS as K8s Secret
+    participant RL as Reloader
+    participant App as App Pod
+
+    PC->>CS: Password rotated (CPM or manual)
+    CS->>CC: Sync updated variable value
+
+    loop Every 15 seconds
+        ESO->>SA: Request JWT token (TokenRequest API)
+        SA-->>ESO: Signed JWT (sub = eso-reloader-sa)
+
+        ESO->>CC: POST /authn-jwt/zg-eso/conjur/authenticate
+        Note over CC: Validate JWT signature<br/>Match sub → host identity<br/>Check authenticator + safe access
+        CC-->>ESO: Conjur access token
+
+        ESO->>CC: GET /secrets/.../account-ssh-user-1/password
+        CC-->>ESO: Current password value
+
+        alt Value changed
+            ESO->>KS: Update K8s Secret
+        end
+    end
+
+    RL->>KS: Detect Secret change
+    RL->>App: Trigger rolling restart
+    Note over App: New pod starts with<br/>updated env vars
+    App->>KS: Read volume mount (auto-updated)
+    App->>KS: Read env vars (from restart)
+```
+
+## Core Validation
+
+Verify ESO controller is running:
+
+```bash
+kubectl get pods -n external-secrets
+```
+
+Verify demo resources:
+
+```bash
+kubectl get sa,secretstore,externalsecret,secret,deployment -n eso-reloader
+```
+
+Expected: one ServiceAccount, one SecretStore (`Valid`), one ExternalSecret (`SecretSynced`), one Secret, one Deployment (`1/1`).
+
+## Pattern 1: ESO Refresh Interval
+
+### What it does
+
+The ExternalSecret's `refreshInterval: 15s` drives the rotation detection. Every 15 seconds ESO re-authenticates to Conjur via JWT and fetches the current secret values. If the values differ from the existing K8s Secret, ESO updates it in place.
+
+### What to validate
+
+**ExternalSecret refresh interval and sync status:**
+
+```bash
+kubectl get externalsecret -n eso-reloader db-credentials -o wide
+```
+
+Look for `STATUS: SecretSynced` and a `LAST SYNC` timestamp within the last 15 seconds.
+
+**Detailed sync conditions:**
+
+```bash
+kubectl describe externalsecret -n eso-reloader db-credentials
+```
+
+The `Conditions` section shows the last successful sync and any errors.
+
+**Current secret values:**
+
+```bash
+kubectl get secret -n eso-reloader db-credentials \
+  -o jsonpath="{.data.username}" | base64 --decode && echo
+
+kubectl get secret -n eso-reloader db-credentials \
+  -o jsonpath="{.data.password}" | base64 --decode && echo
+```
+
+### What the result proves
+
+ESO continuously syncs from Conjur Cloud at the configured interval. When the upstream value changes (Privilege Cloud rotation → Conjur Sync → Conjur Cloud), ESO detects and propagates it to the K8s Secret within one refresh cycle.
+
+### CyberArk behavior
+
+Each refresh cycle:
+
+1. ESO requests a JWT from the K8s TokenRequest API for `eso-reloader-sa` with audience `https://conjur.cyberark.com`.
+2. ESO POSTs the JWT to Conjur's `authn-jwt/zg-eso` endpoint.
+3. Conjur fetches the cluster's JWKS keys to validate the signature.
+4. Conjur extracts `sub` and prepends `identity-path` (`data/poc-workloads`) to resolve the host.
+5. Conjur checks authenticator membership and safe consumer access.
+6. Conjur returns the variable value. ESO updates the K8s Secret if changed.
+
+## Pattern 2: Volume Mount Auto-Update
+
+### What it does
+
+The application pod mounts `db-credentials` as files at `/etc/secrets/`. When the K8s Secret changes, kubelet automatically updates the mounted files within ~60-90 seconds. No pod restart required.
+
+### What to validate
+
+```bash
+POD=$(kubectl get pods -n eso-reloader -l app=rotation-demo-app -o jsonpath='{.items[0].metadata.name}')
+
+kubectl exec -n eso-reloader "$POD" -c app -- cat /etc/secrets/username && echo
+kubectl exec -n eso-reloader "$POD" -c app -- cat /etc/secrets/password && echo
+```
+
+After changing the password in Privilege Cloud, wait ~90 seconds and re-run. The file contents should reflect the new value without any pod restart.
+
+### What the result proves
+
+Applications reading secrets from volume-mounted files get automatic rotation with zero changes. This is the lowest-friction consumption pattern for rotation-sensitive workloads.
+
+## Pattern 3: Reloader Pod Restart for Env Vars
+
+### What it does
+
+Environment variables are set at pod creation and frozen for the pod's lifetime. Stakater Reloader watches for K8s Secret changes and triggers a rolling restart on any Deployment annotated with `reloader.stakater.com/auto: "true"`. The new pod starts with the updated environment variables.
+
+### What to validate
+
+**Reloader is running:**
+
+```bash
+kubectl get pods -A -l app.kubernetes.io/name=reloader
+```
+
+**Deployment has the Reloader annotation:**
+
+```bash
+kubectl get deployment -n eso-reloader rotation-demo-app \
+  -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}' && echo
+```
+
+**After rotation — check pod age:**
+
+```bash
+kubectl get pods -n eso-reloader -l app=rotation-demo-app
+```
+
+If Reloader detected the secret change, the pod's `AGE` should be recent (seconds/minutes, not hours).
+
+**Verify updated env vars in the new pod:**
+
+```bash
+POD=$(kubectl get pods -n eso-reloader -l app=rotation-demo-app -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n eso-reloader "$POD" -c app -- env | grep DB_
+```
+
+### What the result proves
+
+Even for applications that consume secrets via environment variables, rotation is fully automatic. Reloader closes the gap between K8s Secret updates and application awareness.
+
+## Compare the Patterns
+
+| Aspect | Volume Mount | Environment Variable + Reloader |
+|---|---|---|
+| Update mechanism | Kubelet syncs files automatically | Reloader triggers rolling restart |
+| Propagation delay | ~60-90 seconds | Depends on Reloader poll + pod restart time |
+| Application change | None (read from file) | None (read from env var) |
+| Pod restart | No | Yes (rolling, zero-downtime) |
+| Best for | Config files, connection strings, certificates | Apps that read secrets once at startup |
+
+Both patterns are valid. Volume mounts are lower-friction; env vars with Reloader provide a clearer restart boundary for applications that cache credentials in memory.
+
+## Troubleshooting
+
+### SecretStore not valid
+
+```bash
+kubectl describe secretstore -n eso-reloader conjur
+```
+
+| Condition | Likely cause |
+|---|---|
+| `could not validate` | Conjur URL unreachable or TLS issue |
+| `401 Unauthorized` | Host not in authenticator `apps` group, or `identity-path` mismatch |
+
+### ExternalSecret not syncing
+
+```bash
+kubectl describe externalsecret -n eso-reloader db-credentials
+```
+
+| Condition | Likely cause |
+|---|---|
+| `SecretSyncedError` | SecretStore unhealthy — fix SecretStore first |
+| `401 Unauthorized` | Host missing safe access (`delegation/consumers`) |
+| `404 Not Found` | Variable path wrong — check `data/vault/k8s-eso/<account>/<property>` |
+
+### Rotation not detected
+
+1. Verify the password changed in Privilege Cloud.
+2. Check Conjur Synchronizer replicated the change (Conjur Cloud UI or API).
+3. Confirm the ExternalSecret `refreshInterval` is `15s`.
+4. Check ESO logs: `kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=50`
+
+### Reloader not restarting pods
+
+1. Verify Reloader is running: `kubectl get pods -A -l app.kubernetes.io/name=reloader`
+2. Verify the annotation: `reloader.stakater.com/auto: "true"` on the Deployment.
+3. Check Reloader logs: `kubectl logs -n reloader -l app.kubernetes.io/name=reloader --tail=30`
+
+### ESO controller logs
+
+```bash
+kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets --tail=50
+```
+
+Look for `reconcile error`, `401`, or `could not authenticate` messages.

--- a/demos/secrets_manager/k8s/eso-reloader/deployment.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rotation-demo-app
+  namespace: eso-reloader
+  labels:
+    app: rotation-demo-app
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rotation-demo-app
+  template:
+    metadata:
+      labels:
+        app: rotation-demo-app
+    spec:
+      serviceAccountName: eso-reloader-sa
+      containers:
+        - name: app
+          image: alpine/curl
+          command: ["sleep", "infinity"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: password
+          volumeMounts:
+            - name: db-creds-vol
+              mountPath: /etc/secrets
+              readOnly: true
+      volumes:
+        - name: db-creds-vol
+          secret:
+            secretName: db-credentials

--- a/demos/secrets_manager/k8s/eso-reloader/externalsecret.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: db-credentials
+  namespace: eso-reloader
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: conjur
+    kind: SecretStore
+  target:
+    name: db-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: data/vault/k8s-eso/account-ssh-user-1/username
+    - secretKey: password
+      remoteRef:
+        key: data/vault/k8s-eso/account-ssh-user-1/password

--- a/demos/secrets_manager/k8s/eso-reloader/namespace.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: eso-reloader
+  labels:
+    demo: eso-reloader

--- a/demos/secrets_manager/k8s/eso-reloader/remove.sh
+++ b/demos/secrets_manager/k8s/eso-reloader/remove.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Cleanup: Auto-Rotate K8s Secrets — ESO + CyberArk Conjur Cloud
+set -euo pipefail
+
+NAMESPACE="eso-reloader"
+
+echo "[INFO] Removing ESO Auto-Rotation Demo"
+
+echo "[INFO] Deleting ExternalSecret"
+kubectl delete externalsecret -n "$NAMESPACE" db-credentials --ignore-not-found
+
+echo "[INFO] Deleting SecretStore"
+kubectl delete secretstore -n "$NAMESPACE" conjur --ignore-not-found
+
+echo "[INFO] Deleting deployment"
+kubectl delete deployment -n "$NAMESPACE" rotation-demo-app --ignore-not-found
+
+echo "[INFO] Deleting service account"
+kubectl delete sa -n "$NAMESPACE" eso-reloader-sa --ignore-not-found
+
+echo "[INFO] Deleting namespace"
+kubectl delete ns "$NAMESPACE" --ignore-not-found
+
+echo "[INFO] Cleanup complete"
+echo "[NOTE] ESO and Reloader are left installed (shared infrastructure)."
+echo "[NOTE] Conjur policies are not removed. Remove them manually if needed."

--- a/demos/secrets_manager/k8s/eso-reloader/secretstore.tmpl.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/secretstore.tmpl.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: conjur
+  namespace: eso-reloader
+spec:
+  provider:
+    conjur:
+      url: https://${TENANT_SUBDOMAIN}.secretsmgr.cyberark.cloud/api
+      auth:
+        jwt:
+          account: conjur
+          serviceID: ${SM_AUTHN_ID}
+          serviceAccountRef:
+            name: eso-reloader-sa
+            audiences:
+              - https://conjur.cyberark.com

--- a/demos/secrets_manager/k8s/eso-reloader/secretstore.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/secretstore.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: conjur
+  namespace: eso-reloader
+spec:
+  provider:
+    conjur:
+      url: https://zach-lab.secretsmgr.cyberark.cloud/api
+      auth:
+        jwt:
+          account: conjur
+          serviceID: zg-eso
+          serviceAccountRef:
+            name: eso-reloader-sa
+            audiences:
+              - https://conjur.cyberark.com

--- a/demos/secrets_manager/k8s/eso-reloader/service-account.yaml
+++ b/demos/secrets_manager/k8s/eso-reloader/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eso-reloader-sa
+  namespace: eso-reloader

--- a/demos/secrets_manager/k8s/eso-reloader/setup.sh
+++ b/demos/secrets_manager/k8s/eso-reloader/setup.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Setup: Auto-Rotate K8s Secrets — ESO + CyberArk Conjur Cloud
+# Deploys ESO resources, Conjur policies, a sample app, and optionally Reloader.
+set -euo pipefail
+
+trap 'rc=$?; echo "[ERROR] line $LINENO: $BASH_COMMAND (exit=$rc)" >&2; exit $rc' ERR
+
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+NAMESPACE="eso-reloader"
+
+export CYBR_DEMOS_PATH="${CYBR_DEMOS_PATH:-/opt/cybr-demos}"
+
+echo "[INFO] Setting up ESO Auto-Rotation Demo"
+echo "[INFO] CYBR_DEMOS_PATH=$CYBR_DEMOS_PATH"
+echo "[INFO] DEMO_DIR=$DEMO_DIR"
+
+# ── Source shared environment ────────────────────────────
+if [[ -f "$CYBR_DEMOS_PATH/demos/setup_env.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+fi
+
+# ── Verify ESO is installed ─────────────────────────────
+echo "[INFO] Checking ESO installation"
+if ! kubectl get deployment -n external-secrets external-secrets &>/dev/null; then
+  echo "[INFO] ESO not found — installing via Helm"
+  helm repo add external-secrets https://charts.external-secrets.io
+  helm repo update external-secrets
+  helm install external-secrets external-secrets/external-secrets \
+    -n external-secrets --create-namespace --set installCRDs=true
+  kubectl rollout status deployment -n external-secrets external-secrets --timeout=120s
+  kubectl rollout status deployment -n external-secrets external-secrets-webhook --timeout=120s
+  kubectl rollout status deployment -n external-secrets external-secrets-cert-controller --timeout=120s
+else
+  echo "[INFO] ESO already installed"
+fi
+
+# ── Install Reloader (before anything that might fail) ──
+if ! kubectl get deployment -A -l app.kubernetes.io/name=reloader -o name 2>/dev/null | grep -q .; then
+  echo "[INFO] Reloader not found — installing via Helm"
+  helm repo add stakater https://stakater.github.io/stakater-charts
+  helm repo update stakater
+  helm install reloader stakater/reloader -n reloader --create-namespace
+  kubectl rollout status deployment -n reloader reloader-reloader --timeout=60s
+  echo "[INFO] Reloader installed — will auto-restart pods on secret changes"
+else
+  echo "[INFO] Reloader already installed"
+fi
+
+# ── Apply K8s manifests ──────────────────────────────────
+echo "[INFO] Creating namespace and K8s resources"
+kubectl apply -f "$DEMO_DIR/namespace.yaml"
+kubectl apply -f "$DEMO_DIR/service-account.yaml"
+
+# ── Apply Conjur policies ────────────────────────────────
+if [[ -n "${TENANT_ID:-}" && -n "${CLIENT_ID:-}" && -n "${CLIENT_SECRET:-}" ]]; then
+  echo "[INFO] Obtaining CyberArk tokens"
+  identity_token=$(get_identity_token "$TENANT_ID" "$CLIENT_ID" "$CLIENT_SECRET")
+  conjur_token=$(get_conjur_token "$TENANT_SUBDOMAIN" "$identity_token")
+
+  echo "[INFO] Applying Conjur policies"
+
+  echo "[INFO]   1-workload.yaml → data"
+  apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+    "$(cat "$DEMO_DIR/conjur-policy/1-workload.yaml")"
+
+  echo "[INFO]   2-grant-safe-access.yaml → data"
+  apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "data" \
+    "$(cat "$DEMO_DIR/conjur-policy/2-grant-safe-access.yaml")"
+
+  echo "[INFO]   3-grant-authenticator-access.yaml → conjur/authn-jwt"
+  apply_conjur_policy "$TENANT_SUBDOMAIN" "$conjur_token" "conjur/authn-jwt" \
+    "$(cat "$DEMO_DIR/conjur-policy/3-grant-authenticator-access.yaml")"
+else
+  echo "[WARN] Tenant credentials not set — skipping Conjur policy setup."
+  echo "[WARN] Set TENANT_ID, CLIENT_ID, CLIENT_SECRET, and TENANT_SUBDOMAIN"
+  echo "[WARN] or apply the policies in conjur-policy/ manually."
+fi
+
+# ── Apply ESO resources ──────────────────────────────────
+echo "[INFO] Applying SecretStore and ExternalSecret"
+export SM_AUTHN_ID="${SM_AUTHN_ID:-zg-eso}"
+if [[ -z "${TENANT_SUBDOMAIN:-}" ]]; then
+  echo "[ERROR] TENANT_SUBDOMAIN is not set"
+  exit 1
+fi
+export TENANT_SUBDOMAIN SM_AUTHN_ID
+envsubst < "$DEMO_DIR/secretstore.tmpl.yaml" | kubectl apply -f -
+kubectl apply -f "$DEMO_DIR/externalsecret.yaml"
+
+echo "[INFO] Waiting for ExternalSecret to sync..."
+sleep 5
+kubectl get externalsecret -n "$NAMESPACE" db-credentials -o wide
+
+# ── Deploy sample application ────────────────────────────
+echo "[INFO] Deploying sample application"
+kubectl apply -f "$DEMO_DIR/deployment.yaml"
+kubectl rollout status deployment -n "$NAMESPACE" rotation-demo-app --timeout=120s
+
+echo "[INFO] Setup complete"
+echo "[INFO] Run the demo: bash $DEMO_DIR/demo.sh"

--- a/demos/setup_env.sh
+++ b/demos/setup_env.sh
@@ -1,10 +1,24 @@
 #!/bin/bash
 
+# Load tenant credentials and shared helpers. Safe to source from an interactive shell
+# only when CYBR_DEMOS_PATH is set and tenant_vars.sh exists. Prefer: bash <demo>/setup.sh
+
+if [[ -z "${CYBR_DEMOS_PATH:-}" ]]; then
+  echo "[ERROR] CYBR_DEMOS_PATH is not set. Example: export CYBR_DEMOS_PATH=\"\$(pwd)\"" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
 # Set environment variables using .env file
 # -a means that every bash variable would become an environment variable
 # Using ‘+’ rather than ‘-’ causes the option to be turned off
 set -a
-source "$CYBR_DEMOS_PATH/demos/tenant_vars.sh"
+if [[ -f "$CYBR_DEMOS_PATH/demos/tenant_vars.sh" ]]; then
+  # shellcheck source=/dev/null
+  source "$CYBR_DEMOS_PATH/demos/tenant_vars.sh"
+else
+  echo "[WARN] Missing $CYBR_DEMOS_PATH/demos/tenant_vars.sh — create it from README.md (tenant credentials)." >&2
+fi
+# shellcheck source=/dev/null
 source "$CYBR_DEMOS_PATH/demos/utility/ubuntu/identity_functions.sh"
 source "$CYBR_DEMOS_PATH/demos/utility/ubuntu/conjur_functions.sh"
 source "$CYBR_DEMOS_PATH/demos/utility/ubuntu/privilege_functions.sh"

--- a/demos/tenant_vars.sh.example
+++ b/demos/tenant_vars.sh.example
@@ -1,0 +1,13 @@
+# Copy to demos/tenant_vars.sh and fill in real values (never commit tenant_vars.sh).
+#
+#   cp demos/tenant_vars.sh.example demos/tenant_vars.sh
+
+LAB_ID="lab01"
+TENANT_ID="your-tenant-short-id"
+TENANT_SUBDOMAIN="your-subdomain"
+CLIENT_ID="your-service-account@your-subdomain"
+CLIENT_SECRET="your-client-secret"
+
+# Credential Provider demos only (optional elsewhere):
+# INSTALLER_USR="installer-user"
+# INSTALLER_PWD="installer-password"


### PR DESCRIPTION
## Summary

- Adds `demos/secrets_manager/k8s/eso-reloader/` — ESO **15s** `refreshInterval`, sample app consuming secrets via **volume mount** and **env vars**, plus optional **Stakater Reloader** for automatic rollout on secret change.
- Interactive `demo.sh` with live Privilege Cloud rotation polling (same ENTER-to-advance style as `eso/demo.sh`).
- Uses `secretstore.tmpl.yaml` for tenant-specific Conjur URLs.

## Test plan

- [ ] Depends on ESO sub-demo prerequisites — https://github.com/David-Lang/cybr-demos/pull/28 (`k8s-eso` safe, `authn-jwt/zg-eso`)
- [ ] `bash eso-reloader/setup.sh` (installs ESO if missing, Reloader if missing)
- [ ] `bash eso-reloader/demo.sh` — rotation updates K8s Secret, volume file updates, Reloader restarts pod for env vars

## Notes

- **Recommended merge order:** #28 (ESO) → this PR. Sidecar PR (#29 or next) is independent.
- Reuses the same Privilege Cloud safe as `eso/`; separate namespace `eso-reloader` and host identity.

Made with [Cursor](https://cursor.com)