### PR TITLE
secrets_manager/github.com: authoritative GitHub Actions demo (repository JWT auth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ license.txt
 /go.sum
 
 *.idea/*
+.idea/
 
 test_assets/*
 **/secret/*

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ test_assets/*
 
 # Agent working plan (convention: keep planning docs out of git)
 AGENT_PLAN.md
+
+# github.com demo generated artifacts
+demos/secrets_manager/github.com/setup/github/settings_variables.env
+demos/secrets_manager/github.com/setup/conjur/workload1.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ test_assets/*
 **/aws_credentials.env
 **/azure_credentials.env
 **/gcp_credentials.env
+
+# Agent working plan (convention: keep planning docs out of git)
+AGENT_PLAN.md

--- a/demos/secrets_manager/github.com/README.md
+++ b/demos/secrets_manager/github.com/README.md
@@ -48,15 +48,19 @@ sequenceDiagram
 ## Key Files
 
 - `setup.sh`
-  Provisions the safe, the JWT authenticator, and the workload, then maps the values and configures the GitHub repository.
+  Bootstrap + validation: provisions the safe, the JWT authenticator, and the workload, maps the values, configures the GitHub repository, then runs `setup/validate.sh`.
+- `demo.sh`
+  Runs the demo: triggers the GitHub Actions workflows on `GH_REF` (default `aardvark`) via the `gh` CLI and lists the runs.
 - `setup/vars.env`
-  Shared demo configuration: `SAFE_NAME` and `JWT_CLAIM_IDENTITY` (env-overridable).
+  Shared demo configuration: `SAFE_NAME`, `JWT_CLAIM_IDENTITY`, `GH_REPO`, `GH_ENVIRONMENTS`, `TRUFFLEHOG_REPOS`, `TFVAR_*` (all env-overridable).
 - `setup/vault/setup.sh`
   Creates the demo safe, grants required members, and creates `account-ssh-user-1`.
 - `setup/conjur/setup.sh`
   Creates and activates the `github1` JWT authenticator and the `github-actor` workload, and grants safe access.
 - `setup/github/setup.sh`
-  Renders `settings_variables.env` with the `CONJUR_*` values GitHub needs.
+  Maps `CONJUR_*` to `SM_*`, rotates the api-key credential, and configures the GitHub repo via `setup/github/init-gh-vars-secrets.sh`.
+- `setup/validate.sh`
+  Confirms the server side (authenticator, workload, safe delegation) and the GitHub repo (variables, secrets, environments) are in place.
 - `remove.sh`
   Removes the workload and safe artifacts created by setup.
 

--- a/demos/secrets_manager/github.com/README.md
+++ b/demos/secrets_manager/github.com/README.md
@@ -1,31 +1,65 @@
-# Demo: GitHub
+# Demo: GitHub Actions
 
-### About: 
+This demo shows GitHub Actions workflows retrieving secrets from CyberArk Secrets Manager by authenticating with a GitHub OIDC JWT (and, optionally, a workload API key) instead of long-lived static credentials. The secrets are synchronized into Secrets Manager from a Privilege Cloud safe.
 
-### Configuration:
+Use the repo-standard docs for deployment and validation:
 
+- `demo_setup.md`
+- `demo_validation.md`
 
-### Workflow:
+Official CyberArk references for this use case:
+
+- [Secrets Manager authentication methods](https://docs.cyberark.com/secrets-manager-saas/latest/en/content/operations/authn/authn-lp.htm)
+- [Set up JWT authentication](https://docs.cyberark.com/secrets-manager-saas/latest/en/content/operations/authn/authenticate-jwt-config.htm)
+
+GitHub references for OIDC:
+
+- [About security hardening with OpenID Connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+- [OIDC configuration endpoint](https://token.actions.githubusercontent.com/.well-known/openid-configuration)
+
+## About
+
+- GitHub Actions requests a short-lived OIDC JWT that carries the workflow `actor` claim.
+- The `authn-jwt/github1` authenticator validates that JWT against the GitHub JWKS and issuer.
+- Secrets Manager maps the `actor` claim to a Conjur host under `data/workloads/github-actor`.
+- Conjur authorizes that host to read variables synchronized from the demo safe.
+- The workflows in the `idira-github-actions` repo consume the result via the `cyberark/conjur-action` plugin, raw `curl`, or the Conjur Terraform provider.
+
+## Workflow
 
 ```mermaid
 sequenceDiagram
-    
-````
+    autonumber
+    participant GHA as GitHub Actions job
+    participant OIDC as GitHub OIDC provider
+    participant JWT as authn-jwt/github1
+    participant Conjur as Conjur Policy + Variables
+    participant Vault as Privilege Cloud Safe
 
-### Example:
-
-```shell
+    GHA->>OIDC: Request OIDC JWT (actor claim)
+    OIDC-->>GHA: Signed JWT
+    GHA->>JWT: Authenticate with JWT
+    JWT->>Conjur: Map actor to Conjur host
+    Conjur->>Vault: Read synced safe variables
+    Vault-->>Conjur: Return account values
+    Conjur-->>GHA: Authorize and return session token / values
 ```
-```json
-{
 
-}
-```
+## Key Files
 
-https://token.actions.githubusercontent.com/.well-known/openid-configuration  
+- `setup.sh`
+  Provisions the safe, the JWT authenticator, and the workload, then renders the GitHub handoff values.
+- `setup/vars.env`
+  Shared demo configuration: `SAFE_NAME` and `JWT_CLAIM_IDENTITY` (env-overridable).
+- `setup/vault/setup.sh`
+  Creates the demo safe, grants required members, and creates `account-ssh-user-1`.
+- `setup/conjur/setup.sh`
+  Creates and activates the `github1` JWT authenticator and the `github-actor` workload, and grants safe access.
+- `setup/github/setup.sh`
+  Renders `settings_variables.env` with the `CONJUR_*` values GitHub needs.
+- `remove.sh`
+  Removes the workload and safe artifacts created by setup.
 
-https://github.blog/changelog/2021-10-27-github-actions-secure-cloud-deployments-with-openid-connect/
+## GitHub Handoff
 
-https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers 
-
-
+This demo provisions the Secrets Manager server side. The GitHub repository variables, secrets, and environments are populated by the `idira-github-actions` repo, whose `scripts/bootstrap-poc.sh` runs this setup, maps `CONJUR_* -> SM_*`, provisions the api-key credential, and calls `scripts/init-gh-vars-secrets.sh`.

--- a/demos/secrets_manager/github.com/README.md
+++ b/demos/secrets_manager/github.com/README.md
@@ -48,7 +48,7 @@ sequenceDiagram
 ## Key Files
 
 - `setup.sh`
-  Provisions the safe, the JWT authenticator, and the workload, then renders the GitHub handoff values.
+  Provisions the safe, the JWT authenticator, and the workload, then maps the values and configures the GitHub repository.
 - `setup/vars.env`
   Shared demo configuration: `SAFE_NAME` and `JWT_CLAIM_IDENTITY` (env-overridable).
 - `setup/vault/setup.sh`
@@ -60,6 +60,6 @@ sequenceDiagram
 - `remove.sh`
   Removes the workload and safe artifacts created by setup.
 
-## GitHub Handoff
+## GitHub Configuration
 
-This demo provisions the Secrets Manager server side. The GitHub repository variables, secrets, and environments are populated by the `idira-github-actions` repo, whose `scripts/bootstrap-poc.sh` runs this setup, maps `CONJUR_* -> SM_*`, provisions the api-key credential, and calls `scripts/init-gh-vars-secrets.sh`.
+This demo is authoritative for both sides. `setup/github/setup.sh` maps the rendered `CONJUR_*` values to the `SM_*` names the workflows consume, provisions the api-key credential (by rotating the workload host key), and calls `setup/github/init-gh-vars-secrets.sh` to create the repository variables, secrets, and environments in `GH_REPO`. The `idira-github-actions` repo holds only the workflows, Terraform config, and docs. Requires the `gh` CLI authenticated for `GH_REPO`.

--- a/demos/secrets_manager/github.com/demo.sh
+++ b/demos/secrets_manager/github.com/demo.sh
@@ -1,11 +1,62 @@
 #!/bin/bash
+# shellcheck disable=SC2059
+# Runs the github.com demo: triggers the GitHub Actions workflows via the gh CLI.
+# Assumes setup.sh has already provisioned the server side and configured the repo.
 set -euo pipefail
 
-source "$CYBR_DEMOS_PATH/demo_utility.sh"
+demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
 
-echo "Run the Workflow via github.com"
-echo
-# shellcheck disable=SC2154
-printf "${Url_Blue}https://github.com/tbd_account/tbd_repo/actions/${Color_Off}\n"
-echo ""
-echo
+# Load demo inputs (GH_REPO, GH_ENVIRONMENTS, TRUFFLEHOG_REPOS, TFVAR_*).
+set -a
+# shellcheck disable=SC1091
+source "$demo_path/setup/vars.env"
+set +a
+
+# Ref to run the workflows on (branch or tag present on the remote).
+GH_REF="${GH_REF:-aardvark}"
+
+run_workflow() {
+  local wf="$1"
+  printf "  [run] %s\n" "$wf"
+  gh workflow run "$wf" --ref "$GH_REF" --repo "$GH_REPO"
+}
+
+skip_workflow() {
+  printf "  [skip] %s\n" "$*"
+}
+
+main() {
+  command -v gh >/dev/null 2>&1 || { printf "ERROR: gh CLI is required\n" >&2; exit 1; }
+  : "${GH_REPO:?GH_REPO must be set}"
+  gh auth status >/dev/null
+
+  printf "\nRunning GitHub Actions demos on %s (ref: %s)\n\n" "$GH_REPO" "$GH_REF"
+
+  # Core workflows (repo-level vars/secrets are enough).
+  run_workflow "sm-plugin-jwt.yml"
+  run_workflow "sm-direct-jwt.yml"
+  run_workflow "sm-plugin-apikey.yml"
+  run_workflow "sm-plugin-jwt-env-aware.yml"
+  run_workflow "trufflehog-single-scan.yml"
+
+  # Terraform needs an AWS-credentials JSON secret (TFVAR_sm_secret_id_1).
+  if [ -n "${TFVAR_sm_secret_id_1:-}" ]; then
+    run_workflow "sm-plugin-jwt-terraform.yml"
+  else
+    skip_workflow "sm-plugin-jwt-terraform.yml (set TFVAR_sm_secret_id_1 to an AWS-creds JSON secret to run)"
+  fi
+
+  # Multi-scan needs a repo list.
+  if [ -n "${TRUFFLEHOG_REPOS:-}" ]; then
+    run_workflow "trufflehog-multi-scan.yml"
+  else
+    skip_workflow "trufflehog-multi-scan.yml (set TRUFFLEHOG_REPOS to run)"
+  fi
+
+  printf "\nDispatched. Recent runs:\n\n"
+  gh run list --repo "$GH_REPO" --branch "$GH_REF" --limit 10
+
+  printf "\nWatch a run with:\n  gh run watch <run-id> --repo %s\n" "$GH_REPO"
+}
+
+main "$@"

--- a/demos/secrets_manager/github.com/demo_setup.md
+++ b/demos/secrets_manager/github.com/demo_setup.md
@@ -11,11 +11,14 @@ cd "$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
 ./setup.sh
 ```
 
-`setup.sh` sources `setup/vars.env` and runs three stages in order:
+`setup.sh` validates required inputs, sources `setup/vars.env`, and runs these stages in order:
 
 1. `setup/vault/setup.sh` — create the demo safe and a sample account.
 2. `setup/conjur/setup.sh` — create and activate the `github1` JWT authenticator and the workload identity.
-3. `setup/github/setup.sh` — render `settings_variables.env` with the values GitHub needs.
+3. `setup/github/setup.sh` — map `CONJUR_* -> SM_*`, rotate the api-key credential, and configure the GitHub repo.
+4. `setup/validate.sh` — confirm the server side and the GitHub repo configuration are in place.
+
+After setup, run the demo (trigger the workflows) with `./demo.sh` (see `demo_validation.md`).
 
 To reset before another attempt:
 

--- a/demos/secrets_manager/github.com/demo_setup.md
+++ b/demos/secrets_manager/github.com/demo_setup.md
@@ -1,6 +1,6 @@
 # GitHub Actions Demo Setup
 
-This demo provisions the CyberArk Secrets Manager (Idira) server side for GitHub Actions integrations. It creates a JWT authenticator for GitHub OIDC, a workload identity for a GitHub `actor`, and a Privilege Cloud safe whose secrets are synchronized into Secrets Manager. It then emits the values the GitHub workflows in the `idira-github-actions` repo consume.
+This demo provisions the CyberArk Secrets Manager (Idira) server side for GitHub Actions integrations **and** configures the target GitHub repository. It creates a JWT authenticator for GitHub OIDC, a workload identity for a GitHub `actor`, and a Privilege Cloud safe whose secrets are synchronized into Secrets Manager, then maps those values and pushes them to the GitHub repo (variables, secrets, environments). This demo is authoritative; the `idira-github-actions` repo only holds the workflows, Terraform config, and docs.
 
 ## Main Entry Point
 
@@ -32,13 +32,14 @@ The repo-specific setup path matters because:
 - the safe is provisioned by this repo's shared Privilege Cloud helpers,
 - the JWT authenticator and workload policies are created from templates in `setup/conjur/`,
 - the workload identity is derived from the GitHub `actor` claim you provide,
-- the GitHub-side values are rendered into `setup/github/settings_variables.env` for handoff.
+- the GitHub-side values are mapped from the rendered `CONJUR_*` and pushed to the repo.
 
 ## Required Environment
 
 Prerequisites:
 
 - Linux/macOS with `bash`, `curl`, and `jq`.
+- The GitHub CLI (`gh`) installed and authenticated with access to `GH_REPO`.
 - `CYBR_DEMOS_PATH` exported and pointing to this repo checkout.
 - Tenant variables available through `demos/setup_env.sh` (`demos/tenant_vars.sh` or environment): `LAB_ID`, `TENANT_ID`, `TENANT_SUBDOMAIN`, `CLIENT_ID`, `CLIENT_SECRET`.
 - The service account (`CLIENT_ID`/`CLIENT_SECRET`) must have policy-admin rights (`Conjur_Cloud_Admins`) to create authenticators and workloads.
@@ -48,6 +49,10 @@ The setup uses `setup/vars.env` as the shared demo configuration file. It reads 
 
 - `SAFE_NAME` — the Privilege Cloud safe to create/use (default `poc-github`).
 - `JWT_CLAIM_IDENTITY` — the GitHub `actor` claim value (your GitHub username). Required; the default is a placeholder.
+- `GH_REPO` — target GitHub repository `owner/repo` (default `David-Lang/idira-github-actions`).
+- `GH_ENVIRONMENTS` — environments to create/seed (default `dev staging main terraform`).
+- `TRUFFLEHOG_REPOS` — optional repo list for the trufflehog demo.
+- `TFVAR_SSL_CERT`, `TFVAR_sm_secret_id_1` — optional Terraform overrides (derived if blank).
 
 ## Setup Flow
 
@@ -75,9 +80,9 @@ The setup uses `setup/vars.env` as the shared demo configuration file. It reads 
 - activates `authn-jwt/github1`,
 - renders and applies `workload1.yaml`, creating the host `data/workloads/github-actor/<JWT_CLAIM_IDENTITY>` (annotated `authn/api-key: true`) and granting it to the authenticator consumers group and to `vault/<safe>/delegation/consumers`.
 
-### Stage 3: Render the GitHub Handoff Values
+### Stage 3: Configure the GitHub Repository
 
-`setup/github/setup.sh` renders `settings_variables.env` from `settings_variables.tmpl.env`, producing:
+`setup/github/setup.sh` renders `settings_variables.env` from `settings_variables.tmpl.env`, producing the `CONJUR_*` values, then maps and pushes them to GitHub (see "GitHub Configuration" below). The rendered values are:
 
 - `CONJUR_ACCOUNT="conjur"`
 - `CONJUR_JWT_AUTHN_ID="github1"`
@@ -85,15 +90,23 @@ The setup uses `setup/vars.env` as the shared demo configuration file. It reads 
 - `CONJUR_SECRET_ID_2="data/vault/<safe>/account-ssh-user-1/password"`
 - `CONJUR_URL="https://<subdomain>.secretsmgr.cyberark.cloud/api"`
 
-## GitHub Handoff (client side)
+## GitHub Configuration (Option A: authoritative)
 
-This demo provisions the server side only. The GitHub repository variables, secrets, and environments are populated by the `idira-github-actions` repo. Its `scripts/bootstrap-poc.sh` runs this `setup.sh`, maps `CONJUR_* -> SM_*`, provisions the api-key credential by rotating the workload host's API key, and calls `scripts/init-gh-vars-secrets.sh`.
+This demo owns the full flow. `setup/github/setup.sh`:
+
+- renders `settings_variables.env` (the `CONJUR_*` values),
+- maps them to the `SM_*` names the workflows consume,
+- provisions the api-key credential by rotating the workload host's API key (kept in-process, pushed straight to GitHub as a secret),
+- derives the Terraform (`TFVAR_*`) values, and
+- calls `setup/github/init-gh-vars-secrets.sh` to create the repo variables, secrets, and environments in `GH_REPO`.
+
+Requires the `gh` CLI to be installed and authenticated for `GH_REPO`.
 
 ## What Gets Deployed
 
 Local artifacts:
 
-- `setup/github/settings_variables.env` (rendered handoff values)
+- `setup/github/settings_variables.env` (rendered `CONJUR_*` values; git-ignored)
 - `setup/conjur/workload1.yaml` (rendered workload policy)
 
 CyberArk-side resources:
@@ -103,10 +116,17 @@ CyberArk-side resources:
 - workload host `data/workloads/github-actor/<JWT_CLAIM_IDENTITY>`
 - grants into the authenticator consumers group and the safe delegation consumers group
 
+GitHub-side resources (in `GH_REPO`):
+
+- repository variables: `SM_URL`, `SM_ACCOUNT`, `SM_JWT_AUTHN_ID`, `SM_SECRET_ID_1`, `SM_SECRET_ID_2` (and optional `TRUFFLEHOG_REPOS`)
+- repository secrets: `SM_USERNAME`, `SM_API_KEY`
+- environments: `dev`, `staging`, `main`, and `terraform` (with `TFVAR_*`)
+
 ## Troubleshooting Setup
 
 - If the safe setup waits indefinitely for synchronization, confirm `Conjur Sync` was added and the synchronizer is healthy.
 - If authenticator or workload creation fails with an authorization error, confirm the service account has `Conjur_Cloud_Admins` rights.
 - If `JWT_CLAIM_IDENTITY` is still the placeholder, export a real GitHub `actor` value before running setup.
+- If the GitHub stage fails, confirm `gh auth status` succeeds and the token can write variables/secrets/environments to `GH_REPO`.
 - If a run fails sourcing the framework, confirm `CYBR_DEMOS_PATH` is exported and `demos/setup_env.sh` resolves the tenant variables.
 - To reset the server side before retrying, run `./remove.sh`.

--- a/demos/secrets_manager/github.com/demo_setup.md
+++ b/demos/secrets_manager/github.com/demo_setup.md
@@ -1,0 +1,112 @@
+# GitHub Actions Demo Setup
+
+This demo provisions the CyberArk Secrets Manager (Idira) server side for GitHub Actions integrations. It creates a JWT authenticator for GitHub OIDC, a workload identity for a GitHub `actor`, and a Privilege Cloud safe whose secrets are synchronized into Secrets Manager. It then emits the values the GitHub workflows in the `idira-github-actions` repo consume.
+
+## Main Entry Point
+
+Run the full setup from the demo directory:
+
+```bash
+cd "$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
+./setup.sh
+```
+
+`setup.sh` sources `setup/vars.env` and runs three stages in order:
+
+1. `setup/vault/setup.sh` — create the demo safe and a sample account.
+2. `setup/conjur/setup.sh` — create and activate the `github1` JWT authenticator and the workload identity.
+3. `setup/github/setup.sh` — render `settings_variables.env` with the values GitHub needs.
+
+To reset before another attempt:
+
+```bash
+./remove.sh
+```
+
+## Deployment Context
+
+This is a control-plane setup, not a host or Kubernetes deployment. The "workload" is a GitHub Actions job that authenticates to Secrets Manager using the repository's GitHub OIDC token.
+
+The repo-specific setup path matters because:
+
+- the safe is provisioned by this repo's shared Privilege Cloud helpers,
+- the JWT authenticator and workload policies are created from templates in `setup/conjur/`,
+- the workload identity is derived from the GitHub `actor` claim you provide,
+- the GitHub-side values are rendered into `setup/github/settings_variables.env` for handoff.
+
+## Required Environment
+
+Prerequisites:
+
+- Linux/macOS with `bash`, `curl`, and `jq`.
+- `CYBR_DEMOS_PATH` exported and pointing to this repo checkout.
+- Tenant variables available through `demos/setup_env.sh` (`demos/tenant_vars.sh` or environment): `LAB_ID`, `TENANT_ID`, `TENANT_SUBDOMAIN`, `CLIENT_ID`, `CLIENT_SECRET`.
+- The service account (`CLIENT_ID`/`CLIENT_SECRET`) must have policy-admin rights (`Conjur_Cloud_Admins`) to create authenticators and workloads.
+- A healthy Conjur Sync so the safe delegation group appears in Secrets Manager.
+
+The setup uses `setup/vars.env` as the shared demo configuration file. It reads these values from the environment (falling back to defaults):
+
+- `SAFE_NAME` — the Privilege Cloud safe to create/use (default `poc-github`).
+- `JWT_CLAIM_IDENTITY` — the GitHub `actor` claim value (your GitHub username). Required; the default is a placeholder.
+
+## Setup Flow
+
+### Stage 1: Provision the Demo Safe
+
+`setup/vault/setup.sh`:
+
+- authenticates with the tenant service account,
+- creates the safe named by `SAFE_NAME`,
+- adds the Privilege Cloud administrators and `Conjur Sync` as members,
+- creates the sample account `account-ssh-user-1`,
+- waits for the synchronized safe delegation group (`vault/<safe>/delegation/consumers`) to appear in Conjur.
+
+### Stage 2: Provision the JWT Authenticator and Workload
+
+`setup/conjur/setup.sh`:
+
+- applies `authenticator_consumers.yaml` (the `data/authenticator/consumers` group),
+- applies `jwt_service_github1.yaml` to create the `conjur/authn-jwt/github1` authenticator,
+- sets the authenticator variables:
+  - `jwks-uri = https://token.actions.githubusercontent.com/.well-known/jwks`
+  - `issuer = https://token.actions.githubusercontent.com`
+  - `token-app-property = actor`
+  - `identity-path = data/workloads/github-actor`
+- activates `authn-jwt/github1`,
+- renders and applies `workload1.yaml`, creating the host `data/workloads/github-actor/<JWT_CLAIM_IDENTITY>` (annotated `authn/api-key: true`) and granting it to the authenticator consumers group and to `vault/<safe>/delegation/consumers`.
+
+### Stage 3: Render the GitHub Handoff Values
+
+`setup/github/setup.sh` renders `settings_variables.env` from `settings_variables.tmpl.env`, producing:
+
+- `CONJUR_ACCOUNT="conjur"`
+- `CONJUR_JWT_AUTHN_ID="github1"`
+- `CONJUR_SECRET_ID_1="data/vault/<safe>/account-ssh-user-1/username"`
+- `CONJUR_SECRET_ID_2="data/vault/<safe>/account-ssh-user-1/password"`
+- `CONJUR_URL="https://<subdomain>.secretsmgr.cyberark.cloud/api"`
+
+## GitHub Handoff (client side)
+
+This demo provisions the server side only. The GitHub repository variables, secrets, and environments are populated by the `idira-github-actions` repo. Its `scripts/bootstrap-poc.sh` runs this `setup.sh`, maps `CONJUR_* -> SM_*`, provisions the api-key credential by rotating the workload host's API key, and calls `scripts/init-gh-vars-secrets.sh`.
+
+## What Gets Deployed
+
+Local artifacts:
+
+- `setup/github/settings_variables.env` (rendered handoff values)
+- `setup/conjur/workload1.yaml` (rendered workload policy)
+
+CyberArk-side resources:
+
+- demo safe named by `SAFE_NAME`, with `account-ssh-user-1`
+- JWT authenticator `conjur/authn-jwt/github1` (activated)
+- workload host `data/workloads/github-actor/<JWT_CLAIM_IDENTITY>`
+- grants into the authenticator consumers group and the safe delegation consumers group
+
+## Troubleshooting Setup
+
+- If the safe setup waits indefinitely for synchronization, confirm `Conjur Sync` was added and the synchronizer is healthy.
+- If authenticator or workload creation fails with an authorization error, confirm the service account has `Conjur_Cloud_Admins` rights.
+- If `JWT_CLAIM_IDENTITY` is still the placeholder, export a real GitHub `actor` value before running setup.
+- If a run fails sourcing the framework, confirm `CYBR_DEMOS_PATH` is exported and `demos/setup_env.sh` resolves the tenant variables.
+- To reset the server side before retrying, run `./remove.sh`.

--- a/demos/secrets_manager/github.com/demo_validation.md
+++ b/demos/secrets_manager/github.com/demo_validation.md
@@ -109,4 +109,4 @@ gh workflow run sm-plugin-apikey.yml --ref aardvark --repo David-Lang/idira-gith
 - `403`/authorization errors on read: confirm the workload host is granted into `vault/<safe>/delegation/consumers` and the secret path is correct.
 - Empty or missing secret: confirm `account-ssh-user-1` exists in the safe and synchronization has completed.
 - API-key pattern failures: re-provision the key (rotate) and confirm `SM_USERNAME` is the full `host/data/workloads/github-actor/<actor>` id.
-- GitHub side missing variables/secrets: re-run `idira-github-actions/scripts/bootstrap-poc.sh` (or `init-gh-vars-secrets.sh`).
+- GitHub side missing variables/secrets: re-run the demo `setup.sh` (its `setup/github` stage is idempotent and re-seeds the repo via `gh`).

--- a/demos/secrets_manager/github.com/demo_validation.md
+++ b/demos/secrets_manager/github.com/demo_validation.md
@@ -1,0 +1,112 @@
+# GitHub Actions Demo Validation
+
+This demo lets GitHub Actions workflows authenticate to CyberArk Secrets Manager (Idira) and read secrets synchronized from a Privilege Cloud safe. The server side is provisioned by `demo_setup.md`; the workflows live in the `idira-github-actions` repository.
+
+## Start Here
+
+Identify the target objects created by setup:
+
+- Tenant: `https://<TENANT_SUBDOMAIN>.secretsmgr.cyberark.cloud`
+- JWT authenticator: `conjur/authn-jwt/github1` (must be active)
+- Workload host: `data/workloads/github-actor/<JWT_CLAIM_IDENTITY>`
+- Safe: `<SAFE_NAME>` (default `poc-github`) with `account-ssh-user-1`
+- Secrets consumed: `data/vault/<SAFE_NAME>/account-ssh-user-1/username` and `.../password`
+
+## About
+
+CyberArk components involved:
+
+- **JWT authenticator (`github1`)** — validates the GitHub OIDC token against the GitHub JWKS/issuer and maps the `actor` claim to a Conjur host under `data/workloads/github-actor`.
+- **Workload identity** — the host `data/workloads/github-actor/<actor>`, which is a consumer of the authenticator and of the safe delegation group. It is annotated `authn/api-key: true`, so it can also authenticate with a rotated API key.
+- **Safe delegation** — synchronization from Privilege Cloud creates `vault/<safe>/delegation/consumers`; the workload is granted into it to read the synced account secrets.
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    participant GHA as GitHub Actions job
+    participant OIDC as GitHub OIDC provider
+    participant SM as Secrets Manager (authn-jwt/github1)
+    participant Vault as Synced safe secrets
+
+    GHA->>OIDC: Request OIDC JWT (actor claim)
+    OIDC-->>GHA: Signed JWT
+    GHA->>SM: POST authn-jwt/github1/authenticate (jwt)
+    SM->>SM: Verify JWT vs jwks-uri / issuer
+    SM->>SM: Map actor -> data/workloads/github-actor/<actor>
+    SM-->>GHA: Short-lived Conjur session token
+    GHA->>Vault: GET secret (session token, SECRET_ID)
+    Vault-->>GHA: Secret value (username / password)
+```
+
+For the api-key pattern, the first two OIDC steps are replaced by the workload host authenticating with `host_id` + rotated `api_key`.
+
+## Core Validation
+
+Confirm the server side is healthy before running any workflow. Obtain a Conjur token (see the demo helpers `get_identity_token` / `get_conjur_token`), then:
+
+- Authenticator status is healthy:
+
+```bash
+curl -s -H "Authorization: Token token=\"$CONJUR_TOKEN\"" \
+  "https://$TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud/api/authn-jwt/github1/conjur/status"
+```
+
+- The workload host exists:
+
+```bash
+curl -s -H "Authorization: Token token=\"$CONJUR_TOKEN\"" \
+  "https://$TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud/api/resources/conjur?kind=host" \
+  | jq -r '.[].id' | grep 'workloads/github-actor'
+```
+
+- The safe delegation consumers group is present (synchronization completed):
+
+```bash
+curl -s -H "Authorization: Token token=\"$CONJUR_TOKEN\"" \
+  "https://$TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud/api/resources/conjur?kind=group" \
+  | jq -r '.[].id' | grep "$SAFE_NAME/delegation/consumers"
+```
+
+## Pattern 1: GitHub OIDC JWT (plugin and direct)
+
+- What it does: the workflow requests a GitHub OIDC JWT and exchanges it for a Conjur session token, then reads the secret.
+- Identity/access controls: the `actor` claim must match the workload host id; the host must be a consumer of `authn-jwt/github1` and of the safe delegation group.
+- Validate with the `idira-github-actions` workflows:
+  - `sm-plugin-jwt.yml` and `sm-plugin-jwt-env-aware.yml` (via `cyberark/conjur-action`)
+  - `sm-direct-jwt.yml` (raw `curl`)
+  - `sm-plugin-jwt-terraform.yml` (the Conjur Terraform provider authenticates with `authn_type = "jwt"`)
+
+```bash
+gh workflow run sm-plugin-jwt.yml --ref aardvark --repo David-Lang/idira-github-actions
+gh run watch --repo David-Lang/idira-github-actions
+```
+
+- What the result proves: no static credential is stored in GitHub; access is granted only to the matching `actor` identity.
+- CyberArk behavior: Secrets Manager verifies the JWT signature/issuer, enforces the `token-app-property`/`identity-path` mapping, and authorizes the read against the synced safe.
+
+## Pattern 2: Host ID + API Key
+
+- What it does: the workflow authenticates with a host id and API key instead of OIDC.
+- Identity/access controls: the same workload host is used; its API key is provisioned by rotating it (`rotate_workload_api_key`), and stored as the GitHub secrets `SM_USERNAME`/`SM_API_KEY`.
+- Validate with `sm-plugin-apikey.yml`:
+
+```bash
+gh workflow run sm-plugin-apikey.yml --ref aardvark --repo David-Lang/idira-github-actions
+```
+
+- What the result proves: the same identity and authorization model works for non-OIDC callers.
+- CyberArk behavior: Secrets Manager authenticates the host with its API key, then authorizes the same synced-safe read.
+
+## Compare The Patterns
+
+- Prefer **Pattern 1 (JWT/OIDC)** for GitHub-hosted workflows: short-lived, no stored secret.
+- Use **Pattern 2 (API key)** for callers that cannot present a GitHub OIDC token, accepting the stored-secret tradeoff and rotation responsibility.
+
+## Troubleshooting
+
+- `401`/authentication errors on JWT: confirm `authn-jwt/github1` is active and `jwks-uri`/`issuer` match GitHub; confirm the `actor` claim matches the workload host id.
+- `403`/authorization errors on read: confirm the workload host is granted into `vault/<safe>/delegation/consumers` and the secret path is correct.
+- Empty or missing secret: confirm `account-ssh-user-1` exists in the safe and synchronization has completed.
+- API-key pattern failures: re-provision the key (rotate) and confirm `SM_USERNAME` is the full `host/data/workloads/github-actor/<actor>` id.
+- GitHub side missing variables/secrets: re-run `idira-github-actions/scripts/bootstrap-poc.sh` (or `init-gh-vars-secrets.sh`).

--- a/demos/secrets_manager/github.com/demo_validation.md
+++ b/demos/secrets_manager/github.com/demo_validation.md
@@ -43,7 +43,16 @@ For the api-key pattern, the first two OIDC steps are replaced by the workload h
 
 ## Core Validation
 
-Confirm the server side is healthy before running any workflow. Obtain a Conjur token (see the demo helpers `get_identity_token` / `get_conjur_token`), then:
+The fastest check is the automated one, which `setup.sh` also runs as its final stage:
+
+```bash
+cd "$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
+./setup/validate.sh
+```
+
+It confirms the JWT authenticator, the workload host, the safe delegation group, and the
+GitHub repository variables/secrets/environments. To spot-check manually, obtain a Conjur
+token (see the demo helpers `get_identity_token` / `get_conjur_token`), then:
 
 - Authenticator status is healthy:
 
@@ -67,6 +76,20 @@ curl -s -H "Authorization: Token token=\"$CONJUR_TOKEN\"" \
   "https://$TENANT_SUBDOMAIN.secretsmgr.cyberark.cloud/api/resources/conjur?kind=group" \
   | jq -r '.[].id' | grep "$SAFE_NAME/delegation/consumers"
 ```
+
+## Run The Demo
+
+Trigger all applicable workflows with the demo runner (leverages the `gh` CLI):
+
+```bash
+cd "$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
+./demo.sh            # runs on GH_REF (default: aardvark)
+GH_REF=main ./demo.sh   # override the ref
+```
+
+`demo.sh` dispatches the core workflows, conditionally runs `sm-plugin-jwt-terraform`
+(when `TFVAR_sm_secret_id_1` is set) and `trufflehog-multi-scan` (when `TRUFFLEHOG_REPOS`
+is set), and lists the resulting runs. The patterns below explain what each proves.
 
 ## Pattern 1: GitHub OIDC JWT (plugin and direct)
 

--- a/demos/secrets_manager/github.com/info.yaml
+++ b/demos/secrets_manager/github.com/info.yaml
@@ -1,6 +1,6 @@
 Category: "Conjur Cloud"
 Name: "github.com"
-Docs: "https://github.com/David-Lang/cybr-demos/tree/main/demos/conjur_cloud/github.com"
+Docs: "https://github.com/David-Lang/cybr-demos/tree/main/demos/secrets_manager/github.com"
 DemoScript: "demo.sh"
 SetupScript: "setup.sh"
 Enabled: false

--- a/demos/secrets_manager/github.com/remove.sh
+++ b/demos/secrets_manager/github.com/remove.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-demo_path="$CYBR_DEMOS_PATH/demos/conjur_cloud/github.com"
+demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
 # Set environment variables using .env file
 # -a means that every bash variable would become an environment variable
 # Using ‘+’ rather than ‘-’ causes the option to be turned off

--- a/demos/secrets_manager/github.com/setup.sh
+++ b/demos/secrets_manager/github.com/setup.sh
@@ -19,6 +19,10 @@ if [ -z "${GH_REPO:-}" ] || [ "${GH_REPO#*INPUT_REQUIRED}" != "$GH_REPO" ]; then
   exit 1
 fi
 
+# ISP Setup (ensure the service user has the Conjur Cloud Admin role)
+cd "$demo_path/setup/isp"
+./setup.sh
+
 # Vault Setup
 cd "$demo_path/setup/vault"
 ./setup.sh

--- a/demos/secrets_manager/github.com/setup.sh
+++ b/demos/secrets_manager/github.com/setup.sh
@@ -30,3 +30,7 @@ cd "$demo_path/setup/conjur"
 # Github Setup
 cd "$demo_path/setup/github"
 ./setup.sh
+
+# Validation (bootstrap + validate live in setup)
+cd "$demo_path/setup"
+./validate.sh

--- a/demos/secrets_manager/github.com/setup.sh
+++ b/demos/secrets_manager/github.com/setup.sh
@@ -9,6 +9,16 @@ set -a
 source "$demo_path/setup/vars.env"
 set +a
 
+# Validate required demo inputs early so a run fails fast with a clear message.
+if [ -z "${JWT_CLAIM_IDENTITY:-}" ] || [ "${JWT_CLAIM_IDENTITY#*INPUT_REQUIRED}" != "$JWT_CLAIM_IDENTITY" ]; then
+  printf 'ERROR: JWT_CLAIM_IDENTITY must be set to the GitHub actor value (in vars.env or the environment).\n' >&2
+  exit 1
+fi
+if [ -z "${GH_REPO:-}" ] || [ "${GH_REPO#*INPUT_REQUIRED}" != "$GH_REPO" ]; then
+  printf 'ERROR: GH_REPO must be set to the target owner/repo (in vars.env or the environment).\n' >&2
+  exit 1
+fi
+
 # Vault Setup
 cd "$demo_path/setup/vault"
 ./setup.sh

--- a/demos/secrets_manager/github.com/setup.sh
+++ b/demos/secrets_manager/github.com/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-demo_path="$CYBR_DEMOS_PATH/demos/conjur_cloud/github.com"
+demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
 # Set environment variables using .env file
 # -a means that every bash variable would become an environment variable
 # Using ‘+’ rather than ‘-’ causes the option to be turned off

--- a/demos/secrets_manager/github.com/setup/conjur/remove.sh
+++ b/demos/secrets_manager/github.com/setup/conjur/remove.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2059
 set -euo pipefail
 
-source "$CYBR_DEMOS_PATH/demos/isp_vars.env.sh"
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 main() {
   set_variables

--- a/demos/secrets_manager/github.com/setup/conjur/setup.sh
+++ b/demos/secrets_manager/github.com/setup/conjur/setup.sh
@@ -59,10 +59,10 @@ set_variables() {
   github1_issuer_value="https://token.actions.githubusercontent.com"
 
   github1_token_app_property_id="conjur/authn-jwt/github1/token-app-property"
-  github1_token_app_property_value="actor"
+  github1_token_app_property_value="repository"
 
   github1_identity_path_id="conjur/authn-jwt/github1/identity-path"
-  github1_identity_path_value="data/workloads/github-actor"
+  github1_identity_path_value="data/workloads/github-repo"
 }
 
 main "$@"

--- a/demos/secrets_manager/github.com/setup/conjur/setup.sh
+++ b/demos/secrets_manager/github.com/setup/conjur/setup.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2059
 set -euo pipefail
 
-source "$CYBR_DEMOS_PATH/demos/isp_vars.env.sh"
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 main() {
   set_variables

--- a/demos/secrets_manager/github.com/setup/conjur/workload1.tmpl.yaml
+++ b/demos/secrets_manager/github.com/setup/conjur/workload1.tmpl.yaml
@@ -1,23 +1,23 @@
 # metadata
 # mode: append-policy
 ---
-# Identity for the application example that uses the authenticator
-# It annotates the host identity to grants it the role to authenticate
+# Identity for the application example that uses the authenticator.
+# The host is matched by the GitHub OIDC `repository` (owner/repo) claim.
 - !host
-  id: workloads/github-actor/{{ .JWT_CLAIM_IDENTITY }}
+  id: workloads/github-repo/{{ .JWT_CLAIM_IDENTITY }}
   annotations:
-    authn-jwt/github1/actor: {{ .JWT_CLAIM_IDENTITY }}
+    authn-jwt/github1/repository: "{{ .JWT_CLAIM_IDENTITY }}"
     authn/api-key: true
 
 - !grant
   roles:
     - !group authenticator/consumers
   members:
-    - !host workloads/github-actor/{{ .JWT_CLAIM_IDENTITY }}
+    - !host workloads/github-repo/{{ .JWT_CLAIM_IDENTITY }}
 
 # Grants safe access to a workload.
 - !grant
   roles:
     - !group vault/{{ .SAFE_NAME }}/delegation/consumers
   members:
-    - !host workloads/github-actor/{{ .JWT_CLAIM_IDENTITY }}
+    - !host workloads/github-repo/{{ .JWT_CLAIM_IDENTITY }}

--- a/demos/secrets_manager/github.com/setup/github/init-gh-vars-secrets.sh
+++ b/demos/secrets_manager/github.com/setup/github/init-gh-vars-secrets.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  setup/github/init-gh-vars-secrets.sh [--repo OWNER/REPO] [--env NAME]... [--non-interactive]
+
+Description:
+  Creates missing GitHub repository variables and secrets for this repo.
+  Optionally initializes selected GitHub environments and their variables/secrets.
+  Existing values are left unchanged.
+
+Value sources:
+  Repository scope:
+    SM_URL
+    SM_ACCOUNT
+    SM_JWT_AUTHN_ID
+    SM_SECRET_ID_1
+    SM_SECRET_ID_2
+    TRUFFLEHOG_REPOS              optional
+    SM_USERNAME                   secret
+    SM_API_KEY                    secret
+
+  Environment scope:
+    Provide environment-specific values as ENVNAME__KEY, for example:
+      DEV__SM_URL
+      STAGING__SM_SECRET_ID_1
+      MAIN__SM_SECRET_ID_2
+      TERRAFORM__TFVAR_APPLIANCE_URL
+      TERRAFORM__TFVAR_SSL_CERT
+
+Options:
+  --repo OWNER/REPO    Target repository. Defaults to the current gh repo.
+  --env NAME           Initialize a GitHub environment. Can be repeated.
+  --non-interactive    Do not prompt for missing values. Skip them instead.
+  -h, --help           Show this help.
+EOF
+}
+
+require_cmd() {
+  local cmd=$1
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+error() {
+  printf 'Error: %s\n' "$*" >&2
+}
+
+is_interactive() {
+  [[ -t 0 && -t 1 && "${NON_INTERACTIVE}" == "false" ]]
+}
+
+normalize_scope_prefix() {
+  local scope_name=$1
+  printf '%s' "$scope_name" | tr '[:lower:]-' '[:upper:]_'
+}
+
+resolve_value() {
+  local scope_prefix=${1:-}
+  local key=$2
+  local env_key=$key
+  local value=""
+
+  if [[ -n "$scope_prefix" ]]; then
+    env_key="${scope_prefix}__${key}"
+  fi
+
+  value=${!env_key-}
+
+  if [[ -z "$value" && -z "$scope_prefix" ]]; then
+    value=${!key-}
+  fi
+
+  printf '%s' "$value"
+}
+
+prompt_value() {
+  local label=$1
+  local secret_mode=${2:-false}
+  local value=""
+
+  if ! is_interactive; then
+    printf ''
+    return 0
+  fi
+
+  if [[ "$secret_mode" == "true" ]]; then
+    read -r -s -p "$label: " value
+    printf '\n' >&2
+  else
+    read -r -p "$label: " value
+  fi
+
+  printf '%s' "$value"
+}
+
+gh_env_exists() {
+  local env_name=$1
+  gh api "repos/${REPO}/environments/${env_name}" >/dev/null 2>&1
+}
+
+ensure_environment() {
+  local env_name=$1
+
+  if gh_env_exists "$env_name"; then
+    log "Environment ${env_name} already exists"
+    return 0
+  fi
+
+  log "Creating environment ${env_name}"
+  gh api --method PUT "repos/${REPO}/environments/${env_name}" >/dev/null
+}
+
+gh_variable_exists() {
+  local name=$1
+  shift
+
+  gh variable get "$name" --repo "$REPO" "$@" >/dev/null 2>&1
+}
+
+gh_secret_exists() {
+  local name=$1
+  shift
+
+  gh secret list --repo "$REPO" "$@" --json name --jq '.[].name' 2>/dev/null | grep -Fxq "$name"
+}
+
+ensure_variable() {
+  local name=$1
+  local value=$2
+  shift 2
+  local scope_desc=$1
+  shift
+
+  if gh_variable_exists "$name" "$@"; then
+    log "Variable ${scope_desc}${name} already exists"
+    return 0
+  fi
+
+  if [[ -z "$value" ]]; then
+    log "Skipping variable ${scope_desc}${name}; no value provided"
+    return 0
+  fi
+
+  log "Creating variable ${scope_desc}${name}"
+  gh variable set "$name" --repo "$REPO" "$@" --body "$value"
+}
+
+ensure_secret() {
+  local name=$1
+  local value=$2
+  shift 2
+  local scope_desc=$1
+  shift
+
+  if gh_secret_exists "$name" "$@"; then
+    log "Secret ${scope_desc}${name} already exists"
+    return 0
+  fi
+
+  if [[ -z "$value" ]]; then
+    log "Skipping secret ${scope_desc}${name}; no value provided"
+    return 0
+  fi
+
+  log "Creating secret ${scope_desc}${name}"
+  printf '%s' "$value" | gh secret set "$name" --repo "$REPO" "$@"
+}
+
+ensure_repo_variable() {
+  local name=$1
+  local required=${2:-true}
+  local value
+
+  value=$(resolve_value "" "$name")
+  if [[ -z "$value" && "$required" == "true" ]]; then
+    value=$(prompt_value "Enter repository variable ${name}")
+  fi
+
+  ensure_variable "$name" "$value" "repo:"
+}
+
+ensure_repo_secret() {
+  local name=$1
+  local value
+
+  value=$(resolve_value "" "$name")
+  if [[ -z "$value" ]]; then
+    value=$(prompt_value "Enter repository secret ${name}" true)
+  fi
+
+  ensure_secret "$name" "$value" "repo:"
+}
+
+ensure_environment_variable() {
+  local env_name=$1
+  local key=$2
+  local required=${3:-false}
+  local prefix
+  local value
+
+  prefix=$(normalize_scope_prefix "$env_name")
+  value=$(resolve_value "$prefix" "$key")
+
+  if [[ -z "$value" && "$required" == "true" ]]; then
+    value=$(prompt_value "Enter variable ${key} for environment ${env_name}")
+  fi
+
+  ensure_variable "$key" "$value" "env:${env_name}:" --env "$env_name"
+}
+
+ensure_environment_secret() {
+  local env_name=$1
+  local key=$2
+  local required=${3:-false}
+  local prefix
+  local value
+
+  prefix=$(normalize_scope_prefix "$env_name")
+  value=$(resolve_value "$prefix" "$key")
+
+  if [[ -z "$value" && "$required" == "true" ]]; then
+    value=$(prompt_value "Enter secret ${key} for environment ${env_name}" true)
+  fi
+
+  ensure_secret "$key" "$value" "env:${env_name}:" --env "$env_name"
+}
+
+NON_INTERACTIVE=false
+REPO=""
+ENVIRONMENTS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO=${2:?Missing value for --repo}
+      shift 2
+      ;;
+    --env)
+      ENVIRONMENTS+=("${2:?Missing value for --env}")
+      shift 2
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown argument: $1"
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd gh
+require_cmd grep
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+fi
+
+gh auth status >/dev/null
+
+log "Target repository: ${REPO}"
+
+REPO_REQUIRED_VARS=(
+  SM_URL
+  SM_ACCOUNT
+  SM_JWT_AUTHN_ID
+  SM_SECRET_ID_1
+  SM_SECRET_ID_2
+)
+
+REPO_OPTIONAL_VARS=(
+  TRUFFLEHOG_REPOS
+)
+
+REPO_SECRETS=(
+  SM_USERNAME
+  SM_API_KEY
+)
+
+ENV_OVERRIDE_VARS=(
+  SM_URL
+  SM_ACCOUNT
+  SM_JWT_AUTHN_ID
+  SM_SECRET_ID_1
+  SM_SECRET_ID_2
+)
+
+TERRAFORM_ENV_VARS=(
+  SM_URL
+  SM_ACCOUNT
+  SM_JWT_AUTHN_ID
+  SM_SECRET_ID_1
+  SM_SECRET_ID_2
+  TFVAR_APPLIANCE_URL
+  TFVAR_ACCOUNT
+  TFVAR_SSL_CERT
+  TFVAR_sm_secret_id_1
+)
+
+# Terraform authenticates to Secrets Manager via the GitHub OIDC JWT, so no
+# host login / API key secret is required in the terraform environment.
+TERRAFORM_ENV_SECRETS=()
+
+for key in "${REPO_REQUIRED_VARS[@]}"; do
+  ensure_repo_variable "$key" true
+done
+
+for key in "${REPO_OPTIONAL_VARS[@]}"; do
+  ensure_repo_variable "$key" false
+done
+
+for key in "${REPO_SECRETS[@]}"; do
+  ensure_repo_secret "$key"
+done
+
+for env_name in "${ENVIRONMENTS[@]}"; do
+  ensure_environment "$env_name"
+
+  case "$env_name" in
+    dev|staging|main)
+      for key in "${ENV_OVERRIDE_VARS[@]}"; do
+        ensure_environment_variable "$env_name" "$key" false
+      done
+      ;;
+    terraform)
+      for key in "${TERRAFORM_ENV_VARS[@]}"; do
+        ensure_environment_variable "$env_name" "$key" true
+      done
+      for key in "${TERRAFORM_ENV_SECRETS[@]+"${TERRAFORM_ENV_SECRETS[@]}"}"; do
+        ensure_environment_secret "$env_name" "$key" true
+      done
+      ;;
+    *)
+      error "Unsupported environment: ${env_name}"
+      exit 1
+      ;;
+  esac
+done
+
+log "Initialization complete"

--- a/demos/secrets_manager/github.com/setup/github/setup.sh
+++ b/demos/secrets_manager/github.com/setup/github/setup.sh
@@ -26,7 +26,7 @@ main() {
   # 3. Provision the api-key credential. The workload host created by the conjur
   #    setup is annotated authn/api-key: true, so we rotate its key here and push
   #    it straight to GitHub (never written to disk).
-  local workload_id="data/workloads/github-actor/${JWT_CLAIM_IDENTITY}"
+  local workload_id="data/workloads/github-repo/${JWT_CLAIM_IDENTITY}"
   printf "\n\nProvisioning api-key credential for host/%s\n" "$workload_id"
   local identity_token conjur_token api_key
   identity_token=$(get_identity_token "$isp_id" "$client_id" "$client_secret")

--- a/demos/secrets_manager/github.com/setup/github/setup.sh
+++ b/demos/secrets_manager/github.com/setup/github/setup.sh
@@ -7,11 +7,61 @@ source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 main() {
   set_variables
 
-  printf "\n\nresolve_template workload1.tmpl.yaml workload1.yaml\n"
+  # 1. Render the CONJUR_* handoff values from the demo state.
+  printf "\n\nresolve_template settings_variables.tmpl.env settings_variables.env\n"
   resolve_template "settings_variables.tmpl.env" "settings_variables.env"
 
-  printf "\n\nIn the github repo to be used configure these variables:\n"
-  cat settings_variables.env
+  # 2. Load CONJUR_* and map to the SM_* names the workflows consume.
+  set -a
+  # shellcheck disable=SC1091
+  source "./settings_variables.env"
+  set +a
+
+  export SM_URL="$CONJUR_URL"
+  export SM_ACCOUNT="$CONJUR_ACCOUNT"
+  export SM_JWT_AUTHN_ID="$CONJUR_JWT_AUTHN_ID"
+  export SM_SECRET_ID_1="$CONJUR_SECRET_ID_1"
+  export SM_SECRET_ID_2="$CONJUR_SECRET_ID_2"
+
+  # 3. Provision the api-key credential. The workload host created by the conjur
+  #    setup is annotated authn/api-key: true, so we rotate its key here and push
+  #    it straight to GitHub (never written to disk).
+  local workload_id="data/workloads/github-actor/${JWT_CLAIM_IDENTITY}"
+  printf "\n\nProvisioning api-key credential for host/%s\n" "$workload_id"
+  local identity_token conjur_token api_key
+  identity_token=$(get_identity_token "$isp_id" "$client_id" "$client_secret")
+  conjur_token=$(get_conjur_token "$isp_subdomain" "$identity_token")
+  api_key=$(rotate_workload_api_key "$isp_subdomain" "$conjur_token" "$workload_id")
+  [ -n "$api_key" ] || { printf "ERROR: api-key rotation returned empty for host/%s\n" "$workload_id" >&2; exit 1; }
+  export SM_USERNAME="host/${workload_id}"
+  export SM_API_KEY="$api_key"
+
+  # 4. Terraform (JWT auth) values. Blank overrides are derived from the SM_* set.
+  export TFVAR_APPLIANCE_URL="${TFVAR_APPLIANCE_URL:-$SM_URL}"
+  export TFVAR_ACCOUNT="${TFVAR_ACCOUNT:-$SM_ACCOUNT}"
+  export TFVAR_sm_secret_id_1="${TFVAR_sm_secret_id_1:-$SM_SECRET_ID_1}"
+  export TFVAR_SSL_CERT="${TFVAR_SSL_CERT:-}"
+
+  # init-gh-vars-secrets.sh reads environment-scoped values as ENVNAME__KEY.
+  export TERRAFORM__SM_URL="$SM_URL"
+  export TERRAFORM__SM_ACCOUNT="$SM_ACCOUNT"
+  export TERRAFORM__SM_JWT_AUTHN_ID="$SM_JWT_AUTHN_ID"
+  export TERRAFORM__SM_SECRET_ID_1="$SM_SECRET_ID_1"
+  export TERRAFORM__SM_SECRET_ID_2="$SM_SECRET_ID_2"
+  export TERRAFORM__TFVAR_APPLIANCE_URL="$TFVAR_APPLIANCE_URL"
+  export TERRAFORM__TFVAR_ACCOUNT="$TFVAR_ACCOUNT"
+  export TERRAFORM__TFVAR_SSL_CERT="$TFVAR_SSL_CERT"
+  export TERRAFORM__TFVAR_sm_secret_id_1="$TFVAR_sm_secret_id_1"
+
+  # 5. Populate the GitHub repository (variables, secrets, environments).
+  local env_args=()
+  local e
+  for e in ${GH_ENVIRONMENTS:-dev staging main terraform}; do
+    env_args+=(--env "$e")
+  done
+
+  printf "\n\nPopulating GitHub repo %s (envs: %s)\n" "$GH_REPO" "${GH_ENVIRONMENTS:-dev staging main terraform}"
+  ./init-gh-vars-secrets.sh --repo "$GH_REPO" "${env_args[@]}" --non-interactive
 }
 
 # shellcheck disable=SC2153
@@ -19,9 +69,14 @@ main() {
 set_variables() {
   printf "\nSetting local vars from Env"
 
-  isp_id=$TENANT_ID
-  isp_subdomain=$TENANT_SUBDOMAIN
-  safe_name=$SAFE_NAME
+  isp_id="$TENANT_ID"
+  isp_subdomain="$TENANT_SUBDOMAIN"
+  client_id="$CLIENT_ID"
+  client_secret="$CLIENT_SECRET"
+  safe_name="$SAFE_NAME"
+
+  : "${JWT_CLAIM_IDENTITY:?JWT_CLAIM_IDENTITY must be set (GitHub actor value)}"
+  : "${GH_REPO:?GH_REPO must be set (owner/repo)}"
 }
 
 main "$@"

--- a/demos/secrets_manager/github.com/setup/github/setup.sh
+++ b/demos/secrets_manager/github.com/setup/github/setup.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2059
 set -euo pipefail
 
-source "$CYBR_DEMOS_PATH/demos/isp_vars.env.sh"
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 main() {
   set_variables

--- a/demos/secrets_manager/github.com/setup/isp/setup.sh
+++ b/demos/secrets_manager/github.com/setup/isp/setup.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# shellcheck disable=SC2059
+# Ensures the service account is a member of the Conjur Cloud Admin role so it can
+# obtain a Conjur session token and manage authenticators/workloads/policy.
+set -euo pipefail
+
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+
+# CyberArk Identity role name for the Secrets Manager (Conjur Cloud) admin role.
+CONJUR_ADMIN_ROLE="${CONJUR_ADMIN_ROLE:-ID_SecretManagerConjurCloudAdmin}"
+# How long to wait for Conjur Cloud to sync the new role membership.
+CONJUR_ROLE_WAIT_ATTEMPTS="${CONJUR_ROLE_WAIT_ATTEMPTS:-30}"
+
+main() {
+  set_variables
+
+  printf "\n\nEnsuring service user is a member of %s\n" "$CONJUR_ADMIN_ROLE"
+
+  local identity_token service_user_id
+  identity_token=$(get_identity_token "$isp_id" "$client_id" "$client_secret")
+  service_user_id=$(get_service_user_id "$isp_id" "$identity_token")
+  printf "service_user_id: %s\n" "$service_user_id"
+
+  add_user_to_role "$isp_id" "$identity_token" "$CONJUR_ADMIN_ROLE" "$service_user_id"
+  printf "Added service user to %s\n" "$CONJUR_ADMIN_ROLE"
+
+  # Conjur Cloud syncs ISP role membership on an interval. Wait until the service
+  # user can actually obtain a Conjur session token so later stages don't spin on
+  # an empty token.
+  printf "Waiting for Conjur to recognize the admin role"
+  local attempts=0 conjur_token=""
+  while [ "$attempts" -lt "$CONJUR_ROLE_WAIT_ATTEMPTS" ]; do
+    # Refresh the identity token so it reflects current role membership.
+    identity_token=$(get_identity_token "$isp_id" "$client_id" "$client_secret")
+    conjur_token=$(get_conjur_token "$isp_subdomain" "$identity_token")
+    if [ "${#conjur_token}" -gt 100 ]; then
+      printf " ready\n"
+      return 0
+    fi
+    printf "."
+    sleep 10
+    attempts=$((attempts + 1))
+  done
+
+  printf "\nERROR: Conjur did not recognize the admin role within the timeout.\n" >&2
+  exit 1
+}
+
+# shellcheck disable=SC2153
+set_variables() {
+  isp_id="$TENANT_ID"
+  isp_subdomain="$TENANT_SUBDOMAIN"
+  client_id="$CLIENT_ID"
+  client_secret="$CLIENT_SECRET"
+}
+
+main "$@"

--- a/demos/secrets_manager/github.com/setup/validate.sh
+++ b/demos/secrets_manager/github.com/setup/validate.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# shellcheck disable=SC2059
+# Validates the github.com demo after setup: confirms the Secrets Manager server
+# side and the GitHub repository configuration are in place.
+set -uo pipefail
+
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+# Sourcing the framework enables `set -e`; disable it so soft checks can continue.
+set +e
+
+API="https://${TENANT_SUBDOMAIN}.secretsmgr.cyberark.cloud/api"
+FAIL=0
+pass() { printf "  [PASS] %s\n" "$*"; }
+bad()  { printf "  [FAIL] %s\n" "$*"; FAIL=1; }
+
+list_resources() {
+  # $1 kind, $2 conjur_token
+  curl --silent --location "$API/resources/conjur?kind=$1" \
+    --header "Authorization: Token token=\"$2\""
+}
+
+main() {
+  : "${SAFE_NAME:?SAFE_NAME must be set}"
+  : "${JWT_CLAIM_IDENTITY:?JWT_CLAIM_IDENTITY must be set}"
+  : "${GH_REPO:?GH_REPO must be set}"
+
+  local workload="data/workloads/github-actor/${JWT_CLAIM_IDENTITY}"
+
+  printf "\n== Secrets Manager server side ==\n"
+  local id_token conjur_token
+  id_token=$(get_identity_token "$TENANT_ID" "$CLIENT_ID" "$CLIENT_SECRET")
+  conjur_token=$(get_conjur_token "$TENANT_SUBDOMAIN" "$id_token")
+
+  if list_resources webservice "$conjur_token" | grep -q "authn-jwt/github1"; then
+    pass "JWT authenticator github1 present"
+  else
+    bad "JWT authenticator github1 not found"
+  fi
+
+  if list_resources host "$conjur_token" | grep -q "$workload"; then
+    pass "workload host $workload present"
+  else
+    bad "workload host $workload not found"
+  fi
+
+  if list_resources group "$conjur_token" | grep -q "${SAFE_NAME}/delegation/consumers"; then
+    pass "safe delegation group for $SAFE_NAME present"
+  else
+    bad "safe delegation group for $SAFE_NAME not found (synchronization incomplete?)"
+  fi
+
+  printf "\n== GitHub repository %s ==\n" "$GH_REPO"
+  if ! command -v gh >/dev/null 2>&1; then
+    bad "gh CLI not installed; cannot validate GitHub configuration"
+  else
+    local vars secrets envs v e
+    vars=$(gh variable list --repo "$GH_REPO" --json name --jq '.[].name' 2>/dev/null)
+    secrets=$(gh secret list --repo "$GH_REPO" --json name --jq '.[].name' 2>/dev/null)
+    envs=$(gh api "repos/$GH_REPO/environments" --jq '.environments[].name' 2>/dev/null)
+
+    for v in SM_URL SM_ACCOUNT SM_JWT_AUTHN_ID SM_SECRET_ID_1 SM_SECRET_ID_2; do
+      if printf '%s\n' "$vars" | grep -qx "$v"; then pass "variable $v"; else bad "variable $v missing"; fi
+    done
+    for v in SM_USERNAME SM_API_KEY; do
+      if printf '%s\n' "$secrets" | grep -qx "$v"; then pass "secret $v"; else bad "secret $v missing"; fi
+    done
+    for e in ${GH_ENVIRONMENTS:-dev staging main terraform}; do
+      if printf '%s\n' "$envs" | grep -qx "$e"; then pass "environment $e"; else bad "environment $e missing"; fi
+    done
+  fi
+
+  printf "\n"
+  if [ "$FAIL" -ne 0 ]; then
+    printf "Validation FAILED\n" >&2
+    exit 1
+  fi
+  printf "Validation PASSED\n"
+}
+
+main "$@"

--- a/demos/secrets_manager/github.com/setup/validate.sh
+++ b/demos/secrets_manager/github.com/setup/validate.sh
@@ -24,7 +24,7 @@ main() {
   : "${JWT_CLAIM_IDENTITY:?JWT_CLAIM_IDENTITY must be set}"
   : "${GH_REPO:?GH_REPO must be set}"
 
-  local workload="data/workloads/github-actor/${JWT_CLAIM_IDENTITY}"
+  local workload="data/workloads/github-repo/${JWT_CLAIM_IDENTITY}"
 
   printf "\n== Secrets Manager server side ==\n"
   local id_token conjur_token

--- a/demos/secrets_manager/github.com/setup/vars.env
+++ b/demos/secrets_manager/github.com/setup/vars.env
@@ -1,5 +1,7 @@
 # CyberArk Vault
-SAFE_NAME="poc-github"
+# Values may be overridden by exporting them in the environment (e.g. from the
+# idira-github-actions bootstrap). If unset, the defaults below are used.
+SAFE_NAME="${SAFE_NAME:-poc-github}"
 
 # use the jwt claim value. ex: "actor": "github-name"
-JWT_CLAIM_IDENTITY="INPUT_REQUIRED: github-name"
+JWT_CLAIM_IDENTITY="${JWT_CLAIM_IDENTITY:-INPUT_REQUIRED: github-name}"

--- a/demos/secrets_manager/github.com/setup/vars.env
+++ b/demos/secrets_manager/github.com/setup/vars.env
@@ -1,7 +1,22 @@
 # CyberArk Vault
-# Values may be overridden by exporting them in the environment (e.g. from the
-# idira-github-actions bootstrap). If unset, the defaults below are used.
+# Values may be overridden by exporting them in the environment. If unset, the
+# defaults below are used.
 SAFE_NAME="${SAFE_NAME:-poc-github}"
 
 # use the jwt claim value. ex: "actor": "github-name"
 JWT_CLAIM_IDENTITY="${JWT_CLAIM_IDENTITY:-INPUT_REQUIRED: github-name}"
+
+# GitHub target repository (owner/repo) and the environments to create/seed.
+GH_REPO="${GH_REPO:-David-Lang/idira-github-actions}"
+GH_ENVIRONMENTS="${GH_ENVIRONMENTS:-dev staging main terraform}"
+
+# Optional: trufflehog-multi-scan repo list (space or newline separated).
+TRUFFLEHOG_REPOS="${TRUFFLEHOG_REPOS:-}"
+
+# Terraform demo (JWT auth) optional overrides; blank values are derived from
+# the SM_* values produced by setup.
+# NOTE: TFVAR_sm_secret_id_1 must reference an AWS-credentials JSON secret for
+# `terraform apply` to succeed (defaults to SM_SECRET_ID_1, an SSH username,
+# which will NOT satisfy the Terraform jsondecode()).
+TFVAR_SSL_CERT="${TFVAR_SSL_CERT:-}"
+TFVAR_sm_secret_id_1="${TFVAR_sm_secret_id_1:-}"

--- a/demos/secrets_manager/github.com/setup/vault/remove.sh
+++ b/demos/secrets_manager/github.com/setup/vault/remove.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2059
 set -euo pipefail
 
-source "$CYBR_DEMOS_PATH/demos/isp_vars.env.sh"
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 main() {
   set_variables

--- a/demos/secrets_manager/github.com/setup/vault/setup.sh
+++ b/demos/secrets_manager/github.com/setup/vault/setup.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2059
 set -euo pipefail
 
-source "$CYBR_DEMOS_PATH/demos/isp_vars.env.sh"
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 main() {
   set_variables

--- a/demos/utility/ubuntu/identity_functions.sh
+++ b/demos/utility/ubuntu/identity_functions.sh
@@ -118,6 +118,53 @@ set_user_lock_state() {
 
 }
 
+get_service_user_id() {
+  # $1 isp_id, $2 identity_token
+  # Returns the id (UUID) of the user the identity token belongs to.
+  if [ $# -ne 2 ]; then
+    echo "Usage: get_service_user_id isp_id identity_token" >&2
+    return 1
+  fi
+
+  local response user_id
+  response=$(curl --silent --location --request POST \
+    "https://$1.id.cyberark.cloud/UserMgmt/GetUserInfo" \
+    --header "X-CENTRIFY-NATIVE-CLIENT: true" \
+    --header "Authorization: Bearer $2" \
+    --data '')
+
+  user_id=$(printf '%s' "$response" | jq -r '.Result.Id // empty' 2>/dev/null)
+  if [ -z "$user_id" ]; then
+    printf "\nERROR: GetUserInfo did not return a user Id.\nResponse: %s\n" "$response" >&2
+    return 1
+  fi
+
+  printf '%s' "$user_id"
+}
+
+add_user_to_role() {
+  # $1 isp_id, $2 identity_token, $3 role_name, $4 user_id
+  # Adds a user to a CyberArk Identity role (idempotent).
+  if [ $# -ne 4 ]; then
+    echo "Usage: add_user_to_role isp_id identity_token role_name user_id" >&2
+    return 1
+  fi
+
+  local response success
+  response=$(curl --silent --location --request POST \
+    "https://$1.id.cyberark.cloud/roles/updaterole" \
+    --header "Content-Type: application/json" \
+    --header "Authorization: Bearer $2" \
+    --header "X-IDAP-NATIVE-CLIENT: true" \
+    --data "$(jq -cn --arg n "$3" --arg u "$4" '{Name:$n, Users:{Add:[$u]}}')")
+
+  success=$(printf '%s' "$response" | jq -r '.success // empty' 2>/dev/null)
+  if [ "$success" != "true" ]; then
+    printf "\nERROR: updaterole failed for role %s.\nResponse: %s\n" "$3" "$response" >&2
+    return 1
+  fi
+}
+
 reset_user_password() {
   # $1 isp_id, $2 identity_token, $3 user_uuid, $4 user_secret
   if [ $# -ne 4 ]; then
@@ -153,5 +200,3 @@ reset_user_password() {
   # Optional: echo response for debugging
   # printf '%s\n' "$response"
 }
-
-

--- a/demos/utility/ubuntu/template_functions.sh
+++ b/demos/utility/ubuntu/template_functions.sh
@@ -3,28 +3,53 @@
 resolve_template() {
     # $1 input_file, $2 output_file
     if [ $# -ne 2 ]; then
-        echo "Usage: resolve_template input_file output_file"
+        echo "Usage: resolve_template input_file output_file" >&2
         return 1
     fi
-    input_file="$1"
-    output_file="$2"
+    local input_file="$1"
+    local output_file="$2"
+
+    if [ ! -f "$input_file" ]; then
+        printf "ERROR: resolve_template: input file not found: %s\n" "$input_file" >&2
+        return 1
+    fi
+
     printf "" > "$output_file"
 
-    while IFS= read -r line; do
-        # Use a regular expression to find Go lang style templates with dots
-        # echo "$line"
-        pattern='\{\{\s*\.([A-Za-z][A-Za-z0-9_]*)\s*\}\}'
+    local line pattern pattern_match template_var value
+    # Go-style templates like {{ .VarName }}. Use [[:space:]] (POSIX) rather than
+    # \s, which bash's ERE engine does not support (it silently fails to match
+    # templates that contain whitespace).
+    pattern='\{\{[[:space:]]*\.([A-Za-z][A-Za-z0-9_]*)[[:space:]]*\}\}'
+
+    while IFS= read -r line || [ -n "$line" ]; do
         while [[ $line =~ $pattern ]]; do
-            pattern_match=${BASH_REMATCH[0]}
-            echo "Found pattern: $pattern_match"
-            template_var=${BASH_REMATCH[1]}
-            echo "Variable: $template_var"
+            pattern_match="${BASH_REMATCH[0]}"
+            template_var="${BASH_REMATCH[1]}"
+
+            # Fail explicitly if the referenced variable is unset or empty,
+            # rather than emitting a half-resolved file that breaks downstream.
+            if [ -z "${!template_var+set}" ]; then
+                printf "ERROR: resolve_template: variable '%s' referenced in %s is not set\n" \
+                    "$template_var" "$input_file" >&2
+                return 1
+            fi
             value="${!template_var}"
-            echo "Value: $value"
-            # Replace the template with the environment variable value
+            if [ -z "$value" ]; then
+                printf "ERROR: resolve_template: variable '%s' referenced in %s is empty\n" \
+                    "$template_var" "$input_file" >&2
+                return 1
+            fi
+
             line="${line//$pattern_match/$value}"
         done
-        # Append the modified line to the output file
-        echo "$line" >> "$output_file"
+        printf '%s\n' "$line" >> "$output_file"
     done < "$input_file"
+
+    # Final guard: no unresolved templates may remain in the output.
+    if grep -nE '\{\{[[:space:]]*\.' "$output_file" >/dev/null 2>&1; then
+        printf "ERROR: resolve_template: unresolved templates remain in %s:\n" "$output_file" >&2
+        grep -nE '\{\{' "$output_file" >&2
+        return 1
+    fi
 }


### PR DESCRIPTION
Makes the github.com Secrets Manager demo authoritative for both the server side and the GitHub repository configuration.

## Highlights
- Fix stale paths: conjur_cloud -> secrets_manager; source demos/setup_env.sh (the missing isp_vars.env.sh).
- Authoritative GitHub setup: setup/github maps CONJUR_* -> SM_*, rotates the workload api-key, derives TFVAR_*, and configures the target repo (vars/secrets/environments) via setup/github/init-gh-vars-secrets.sh.
- JWT auth uses the GitHub OIDC **repository** (owner/repo) claim: token-app-property=repository, identity-path=data/workloads/github-repo.
- Add setup/isp stage that grants the service user the Conjur Cloud Admin role and waits for propagation.
- Harden resolve_template: POSIX [[:space:]] (bash ERE has no \s) and explicit failures on unset/empty vars or leftover {{ }}.
- Add identity helpers (get_service_user_id, add_user_to_role); setup.sh runs a final validate stage; demo.sh triggers the workflows via gh.
- Docs: README, demo_setup.md, demo_validation.md; ignore generated artifacts.

Validated end-to-end against a live tenant: setup + validate PASS.