### PR TITLE
github.com demo: authoritative GitHub Actions POC (repository JWT auth + api-key fix)

### DIFF
--- a/demos/secrets_manager/github.com/demo.sh
+++ b/demos/secrets_manager/github.com/demo.sh
@@ -39,12 +39,8 @@ main() {
   run_workflow "sm-plugin-jwt-env-aware.yml"
   run_workflow "trufflehog-single-scan.yml"
 
-  # Terraform needs an AWS-credentials JSON secret (TFVAR_sm_secret_id_1).
-  if [ -n "${TFVAR_sm_secret_id_1:-}" ]; then
-    run_workflow "sm-plugin-jwt-terraform.yml"
-  else
-    skip_workflow "sm-plugin-jwt-terraform.yml (set TFVAR_sm_secret_id_1 to an AWS-creds JSON secret to run)"
-  fi
+  # Terraform reuses the same secret id as the other demos (no AWS JSON needed).
+  run_workflow "sm-plugin-jwt-terraform.yml"
 
   # Multi-scan needs a repo list.
   if [ -n "${TRUFFLEHOG_REPOS:-}" ]; then

--- a/demos/secrets_manager/github.com/demo_setup.md
+++ b/demos/secrets_manager/github.com/demo_setup.md
@@ -52,7 +52,7 @@ The setup uses `setup/vars.env` as the shared demo configuration file. It reads 
 
 - `SAFE_NAME` — the Privilege Cloud safe to create/use (default `poc-github`).
 - `JWT_CLAIM_IDENTITY` — the GitHub `actor` claim value (your GitHub username). Required; the default is a placeholder.
-- `GH_REPO` — target GitHub repository `owner/repo` (default `David-Lang/idira-github-actions`).
+- `GH_REPO` — target GitHub repository `owner/repo` (default `David-Lang/idira-poc-github-actions`).
 - `GH_ENVIRONMENTS` — environments to create/seed (default `dev staging main terraform`).
 - `TRUFFLEHOG_REPOS` — optional repo list for the trufflehog demo.
 - `TFVAR_SSL_CERT`, `TFVAR_sm_secret_id_1` — optional Terraform overrides (derived if blank).

--- a/demos/secrets_manager/github.com/demo_validation.md
+++ b/demos/secrets_manager/github.com/demo_validation.md
@@ -101,8 +101,8 @@ is set), and lists the resulting runs. The patterns below explain what each prov
   - `sm-plugin-jwt-terraform.yml` (the Conjur Terraform provider authenticates with `authn_type = "jwt"`)
 
 ```bash
-gh workflow run sm-plugin-jwt.yml --ref aardvark --repo David-Lang/idira-github-actions
-gh run watch --repo David-Lang/idira-github-actions
+gh workflow run sm-plugin-jwt.yml --ref aardvark --repo David-Lang/idira-poc-github-actions
+gh run watch --repo David-Lang/idira-poc-github-actions
 ```
 
 - What the result proves: no static credential is stored in GitHub; access is granted only to the matching `actor` identity.
@@ -115,7 +115,7 @@ gh run watch --repo David-Lang/idira-github-actions
 - Validate with `sm-plugin-apikey.yml`:
 
 ```bash
-gh workflow run sm-plugin-apikey.yml --ref aardvark --repo David-Lang/idira-github-actions
+gh workflow run sm-plugin-apikey.yml --ref aardvark --repo David-Lang/idira-poc-github-actions
 ```
 
 - What the result proves: the same identity and authorization model works for non-OIDC callers.

--- a/demos/secrets_manager/github.com/setup/vars.env
+++ b/demos/secrets_manager/github.com/setup/vars.env
@@ -14,9 +14,7 @@ GH_ENVIRONMENTS="${GH_ENVIRONMENTS:-dev staging main terraform}"
 TRUFFLEHOG_REPOS="${TRUFFLEHOG_REPOS:-}"
 
 # Terraform demo (JWT auth) optional overrides; blank values are derived from
-# the SM_* values produced by setup.
-# NOTE: TFVAR_sm_secret_id_1 must reference an AWS-credentials JSON secret for
-# `terraform apply` to succeed (defaults to SM_SECRET_ID_1, an SSH username,
-# which will NOT satisfy the Terraform jsondecode()).
+# the SM_* values produced by setup. TFVAR_sm_secret_id_1 reuses SM_SECRET_ID_1
+# by default (the Terraform demo just fetches and outputs that secret).
 TFVAR_SSL_CERT="${TFVAR_SSL_CERT:-}"
 TFVAR_sm_secret_id_1="${TFVAR_sm_secret_id_1:-}"

--- a/demos/secrets_manager/github.com/setup/vars.env
+++ b/demos/secrets_manager/github.com/setup/vars.env
@@ -7,7 +7,7 @@ SAFE_NAME="${SAFE_NAME:-poc-github}"
 JWT_CLAIM_IDENTITY="${JWT_CLAIM_IDENTITY:-INPUT_REQUIRED: github-name}"
 
 # GitHub target repository (owner/repo) and the environments to create/seed.
-GH_REPO="${GH_REPO:-David-Lang/idira-github-actions}"
+GH_REPO="${GH_REPO:-David-Lang/idira-poc-github-actions}"
 GH_ENVIRONMENTS="${GH_ENVIRONMENTS:-dev staging main terraform}"
 
 # Optional: trufflehog-multi-scan repo list (space or newline separated).

--- a/demos/utility/ubuntu/conjur_functions.sh
+++ b/demos/utility/ubuntu/conjur_functions.sh
@@ -100,6 +100,6 @@ rotate_workload_api_key() {
 
   curl --silent \
     --request PUT \
-    --location "https://$1.secretsmgr.cyberark.cloud/api/authn/conjur/api_key?role=host/$3" \
+    --location "https://$1.secretsmgr.cyberark.cloud/api/authn/conjur/api_key?role=host:$3" \
     --header "Authorization: Token token=\"$2\""
 }


### PR DESCRIPTION
Supersedes #41 (includes all of aardvark plus fixes validated end-to-end against a live tenant).

## What this delivers
- **Authoritative github.com demo**: setup provisions the server side (JWT authenticator, workload, safe) AND configures the target GitHub repo (variables/secrets/environments), then validates. demo.sh triggers the workflows via gh.
- **Repository (owner/repo) JWT claim**: token-app-property=repository, identity-path=data/workloads/github-repo.
- **Conjur admin bootstrap**: setup/isp adds the service user to the Conjur Cloud Admin role and waits for propagation.
- **Hardened resolve_template**: POSIX [[:space:]] + explicit failures on unset/empty vars or leftover templates.
- **api-key rotation fix**: role=host:<id> (kind:id); the slash form returned a 422 that was stored as the key.
- Targets the new repo David-Lang/idira-poc-github-actions.

## Validation (live)
setup + validate PASS. Workflows on the new repo: sm-plugin-jwt, sm-direct-jwt, sm-plugin-apikey, trufflehog-single all pass; env-aware fails by design on a non-env branch.