### PR TITLE
Add bruno_api Secrets Manager demo

### DIFF
--- a/compute_init/ubuntu/install_bru.sh
+++ b/compute_init/ubuntu/install_bru.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# Bruno CLI (@usebruno/cli) is distributed via npm and requires Node.js.
+# Install Node 20 (NodeSource) if npm is not already present, then the CLI.
+
+if command -v bru >/dev/null 2>&1; then
+  echo "bru is already installed: $(bru --version 2>/dev/null || true)"
+  exit 0
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Installing Node.js (npm not found)"
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+sudo npm install -g @usebruno/cli
+
+# Verify
+command -v bru
+bru --version

--- a/demos/secrets_manager/bruno_api/.gitignore
+++ b/demos/secrets_manager/bruno_api/.gitignore
@@ -1,0 +1,8 @@
+# Local working state (cloned collection + generated env + run reports)
+.collection/
+*.report.json
+
+# Belt-and-suspenders: never commit secret-bearing Bruno envs, even if a clone's
+# ignore rules change. The generated env is <name>.secret.bru.
+*.secret.bru
+**/*.secret.bru

--- a/demos/secrets_manager/bruno_api/README.md
+++ b/demos/secrets_manager/bruno_api/README.md
@@ -40,13 +40,14 @@ sequenceDiagram
 
     Note over CLI,Vault: Setup App (service / root token)
     CLI->>ISP: platform token (client_credentials)
+    CLI->>Vault: create safe + accounts (Privilege Cloud API)
     CLI->>SM: create workload + RBAC, rotate workload API key
-    SM->>Vault: safe + accounts (synced)
+    Vault-->>SM: Synchronizer syncs safe -> data/vault/<app> variables
 
     Note over CLI,Vault: Demo App (workload identity)
     CLI->>SM: authenticate as workload (API key) -> session token
-    CLI->>Vault: retrieve secret(s) with session token
-    Vault-->>CLI: secret values
+    CLI->>SM: retrieve secret(s) with session token
+    SM-->>CLI: secret values
 ```
 
 ## Key Files
@@ -55,7 +56,11 @@ sequenceDiagram
   Installs the Bruno CLI, clones the collection, generates a git-ignored Bruno env from
   the service creds, runs the Setup App section, and captures the workload API key.
 - `demo.sh`
-  Runs the Demo App section (workload authenticate + retrieve secrets) via `bru run`.
+  Runs the Demo App section (workload authenticate + retrieve secrets) via `bru run`,
+  narrating each request and response.
+- `remove.sh`
+  Tears down the app created by setup (Conjur workload policy, Privilege Cloud safe +
+  accounts, and the ISP `<app>-admins` role).
 - `info.yaml`
   Demo metadata.
 
@@ -71,6 +76,7 @@ CLI:
 cd "$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
 ./setup.sh      # configure the app + capture the workload key
 ./demo.sh       # authenticate as the workload and retrieve secrets
+./remove.sh     # (optional) tear the app back down
 ```
 
 GUI: see `demo_validation.md` — open the cloned collection in Bruno, select the `cybr.secret`

--- a/demos/secrets_manager/bruno_api/README.md
+++ b/demos/secrets_manager/bruno_api/README.md
@@ -1,0 +1,77 @@
+# Demo: Bruno API (ALM API Key Auth)
+
+This demo showcases the CyberArk Secrets Manager **API** using the
+[`poc-sm-saas-bruno`](https://github.com/David-Lang/poc-sm-saas-bruno) Bruno collection.
+It sets up an application (safe, accounts, workload/machine identity, RBAC) and then
+demonstrates a workload authenticating with its API key and retrieving secrets — runnable
+both from the **Bruno CLI** (`bru`) and the **Bruno GUI**.
+
+Use the repo-standard docs for deployment and validation:
+
+- `demo_setup.md`
+- `demo_validation.md`
+
+References:
+
+- [Bruno](https://usebruno.com)
+- [Secrets Manager authentication methods](https://docs.cyberark.com/secrets-manager-saas/latest/en/content/operations/authn/authn-lp.htm)
+
+## About
+
+- The collection's **Setup App** section uses the service account (the "Idira root
+  service token") to configure ISP roles, a Privilege Cloud safe with sample accounts,
+  a Secrets Manager **workload** (machine identity), RBAC grants, and rotates the
+  workload API key.
+- The **Demo App** section authenticates *as the workload* using that API key and
+  retrieves secrets — no human/service credentials at runtime.
+- Inputs map from the shared framework creds: `TENANT_ID -> IspTenantId`,
+  `TENANT_SUBDOMAIN -> IspSubDomain`, `CLIENT_ID -> IspServiceClientId`,
+  `CLIENT_SECRET -> IspServiceClientSecret`, plus `UseCaseAlmAppName`.
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as bru CLI / Bruno GUI
+    participant ISP as CyberArk Identity
+    participant SM as Secrets Manager (Conjur)
+    participant Vault as Privilege Cloud Safe
+
+    Note over CLI,Vault: Setup App (service / root token)
+    CLI->>ISP: platform token (client_credentials)
+    CLI->>SM: create workload + RBAC, rotate workload API key
+    SM->>Vault: safe + accounts (synced)
+
+    Note over CLI,Vault: Demo App (workload identity)
+    CLI->>SM: authenticate as workload (API key) -> session token
+    CLI->>Vault: retrieve secret(s) with session token
+    Vault-->>CLI: secret values
+```
+
+## Key Files
+
+- `setup.sh`
+  Installs the Bruno CLI, clones the collection, generates a git-ignored Bruno env from
+  the service creds, runs the Setup App section, and captures the workload API key.
+- `demo.sh`
+  Runs the Demo App section (workload authenticate + retrieve secrets) via `bru run`.
+- `info.yaml`
+  Demo metadata.
+
+The collection is cloned into `.collection/` (git-ignored); the generated Bruno
+environment `.collection/collection/environments/cybr.secret.bru` holds the service creds
+and captured workload key and is never committed.
+
+## Run it
+
+CLI:
+
+```bash
+cd "$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
+./setup.sh      # configure the app + capture the workload key
+./demo.sh       # authenticate as the workload and retrieve secrets
+```
+
+GUI: see `demo_validation.md` — open the cloned collection in Bruno, select the `cybr.secret`
+environment, and click through the Setup App then Demo App sections.

--- a/demos/secrets_manager/bruno_api/demo.sh
+++ b/demos/secrets_manager/bruno_api/demo.sh
@@ -1,28 +1,113 @@
 #!/bin/bash
 # shellcheck disable=SC2059
-# Runs the "ALM API Key Auth" Demo App section via the Bruno CLI:
-# authenticates as the application workload (using the captured workload API key)
-# and retrieves secrets. Assumes setup.sh has already run.
+# Runs the "ALM API Key Auth" Demo App section via the Bruno CLI and narrates
+# each step: the application workload authenticates to Secrets Manager with its
+# API key (getting a short-lived Conjur session token), then retrieves secrets
+# over the REST API. Assumes setup.sh has already run.
 set -euo pipefail
+
+# Locate the repo root from this script if the lab bootstrap hasn't exported it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${CYBR_DEMOS_PATH:=$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
 demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
 ENV_NAME="cybr.secret"
 WORK_DIR="$demo_path/.collection"
 COLLECTION_DIR="$WORK_DIR/collection"
 ENV_FILE="$COLLECTION_DIR/environments/$ENV_NAME.bru"
+DEMO_FOLDER="Use Cases/ALM API Key Auth/2 Demo App"
+REPORT_FILE="$demo_path/demo.report.json"
 
-main() {
+hr()  { printf '%s\n' "------------------------------------------------------------"; }
+step() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+
+# Read a non-secret value out of the generated Bruno env (<key>: <value>).
+envval() {
+  grep -E "^[[:space:]]*$1:" "$ENV_FILE" | head -1 | sed -E "s/^[[:space:]]*$1:[[:space:]]*//" | tr -d '\r'
+}
+
+preflight() {
   command -v bru >/dev/null 2>&1 || { printf "ERROR: bru CLI not found. Run setup.sh first.\n" >&2; exit 1; }
   [ -f "$COLLECTION_DIR/bruno.json" ] || { printf "ERROR: collection not found. Run setup.sh first.\n" >&2; exit 1; }
   [ -f "$ENV_FILE" ] || { printf "ERROR: Bruno env %s not found. Run setup.sh first.\n" "$ENV_FILE" >&2; exit 1; }
-
-  if ! grep -qE '^\s*almAppName_workload_ApiKey:\s*\S' "$ENV_FILE"; then
+  if ! grep -qE '^[[:space:]]*almAppName_workload_ApiKey:[[:space:]]*\S' "$ENV_FILE"; then
     printf "ERROR: workload API key not present in %s. Re-run setup.sh.\n" "$ENV_FILE" >&2
     exit 1
   fi
+}
 
-  printf "\nRunning Bruno Demo App section (authenticate as workload -> retrieve secrets)\n"
-  ( cd "$COLLECTION_DIR" && bru run "Use Cases/ALM API Key Auth/2 Demo App" -r --env "$ENV_NAME" )
+intro() {
+  local app sub acct lab
+  app="$(envval UseCaseAlmAppName)"
+  sub="$(envval IspSubDomain)"
+  acct="$(envval ConjurAccount)"
+  lab="$(envval LabId)"
+
+  hr
+  printf '\033[1mSecrets Manager — ALM API Key Auth (Demo App)\033[0m\n'
+  hr
+  printf 'A non-human application workload authenticates to CyberArk Secrets Manager\n'
+  printf '(Conjur Cloud) using its own API key, receives a short-lived session token,\n'
+  printf 'and uses that token to read secrets over the REST API.\n\n'
+  printf '  Tenant subdomain : %s.secretsmgr.cyberark.cloud\n' "$sub"
+  printf '  Conjur account   : %s\n' "$acct"
+  printf '  Application (app) : %s   (lab %s)\n' "$app" "$lab"
+  printf '  Workload identity : host/data/%s/%s-workload\n' "$app" "$app"
+  printf '  Workload API key  : present (hidden)\n'
+
+  step "What this demo will do:"
+  printf '  1. Authenticate     POST /api/authn/conjur/host%%2Fdata%%2F%s%%2F%s-workload/authenticate\n' "$app" "$app"
+  printf '                      (body = workload API key)  ->  Conjur session token\n'
+  printf '  2. Retrieve Secret  GET  /api/secrets/conjur/variable/data/vault/%s/account-ssh-user1/password\n' "$app"
+  printf '  3. Batch Retrieve   POST /api/secrets/values   (username + address + password in one call)\n'
+  printf '  4. List Secrets     GET  /api/resources?kind=variable   (what this workload can see)\n'
+}
+
+run_collection() {
+  step "Running the requests (Bruno CLI)..."
+  hr
+  # Runtime session token is set by the Authenticate test and shared across the
+  # folder run; a JSON report is written so we can show the responses below.
+  ( cd "$COLLECTION_DIR" && bru run "$DEMO_FOLDER" -r --env "$ENV_NAME" --reporter-json "$REPORT_FILE" )
+}
+
+render_results() {
+  command -v jq >/dev/null 2>&1 || { printf "\n(install jq to see the per-step response detail)\n"; return 0; }
+  [ -f "$REPORT_FILE" ] || return 0
+
+  step "What happened (requests + responses):"
+  jq -r '
+    (if type=="array" then .[0].results else .results end)[]
+    | (.test.filename | sub(".*/";"") | sub("\\.bru$";"")) as $name
+    | "\n\u25b8 \($name)",
+      "    \(.request.method) \(.request.url)",
+      "    \u2192 \(.response.status) \(.response.statusText // "")  (\((.response.responseTime // .response.duration // 0))ms)",
+      (
+        if ($name | test("Authenticate")) then
+          "    \u21b3 issued a Conjur session token (base64, \((.response.data|tostring|length)) chars) - used as the bearer token for the reads below"
+        elif ($name | test("Retrieve Secret$")) then
+          "    \u21b3 password = \(.response.data)"
+        elif ($name | test("Batch")) then
+          (.response.data.secrets[]? | "    \u21b3 \(.id|sub("^data/vault/[^/]+/";"")) = \(.value)  [\(.status)]")
+        elif ($name | test("List")) then
+          ("    \u21b3 \((.response.data|length)) variable(s) visible to this workload:"),
+          (.response.data[]? | "        - \(.id|sub("^conjur:variable:data/vault/[^/]+/";""))")
+        else
+          "    \u21b3 \(.response.data|tojson|.[0:200])"
+        end
+      )
+  ' "$REPORT_FILE"
+  rm -f "$REPORT_FILE"
+}
+
+main() {
+  preflight
+  intro
+  run_collection
+  render_results
+  step "Demo complete."
+  printf 'The workload never used a human credential: it authenticated with its API key,\n'
+  printf 'got a short-lived Conjur token, and read only the secrets it is authorized for.\n\n'
 }
 
 main "$@"

--- a/demos/secrets_manager/bruno_api/demo.sh
+++ b/demos/secrets_manager/bruno_api/demo.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# shellcheck disable=SC2059
+# Runs the "ALM API Key Auth" Demo App section via the Bruno CLI:
+# authenticates as the application workload (using the captured workload API key)
+# and retrieves secrets. Assumes setup.sh has already run.
+set -euo pipefail
+
+demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
+ENV_NAME="cybr.secret"
+WORK_DIR="$demo_path/.collection"
+COLLECTION_DIR="$WORK_DIR/collection"
+ENV_FILE="$COLLECTION_DIR/environments/$ENV_NAME.bru"
+
+main() {
+  command -v bru >/dev/null 2>&1 || { printf "ERROR: bru CLI not found. Run setup.sh first.\n" >&2; exit 1; }
+  [ -f "$COLLECTION_DIR/bruno.json" ] || { printf "ERROR: collection not found. Run setup.sh first.\n" >&2; exit 1; }
+  [ -f "$ENV_FILE" ] || { printf "ERROR: Bruno env %s not found. Run setup.sh first.\n" "$ENV_FILE" >&2; exit 1; }
+
+  if ! grep -qE '^\s*almAppName_workload_ApiKey:\s*\S' "$ENV_FILE"; then
+    printf "ERROR: workload API key not present in %s. Re-run setup.sh.\n" "$ENV_FILE" >&2
+    exit 1
+  fi
+
+  printf "\nRunning Bruno Demo App section (authenticate as workload -> retrieve secrets)\n"
+  ( cd "$COLLECTION_DIR" && bru run "Use Cases/ALM API Key Auth/2 Demo App" -r --env "$ENV_NAME" )
+}
+
+main "$@"

--- a/demos/secrets_manager/bruno_api/demo_setup.md
+++ b/demos/secrets_manager/bruno_api/demo_setup.md
@@ -22,6 +22,13 @@ cd "$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
 5. Captures the workload API key (using the service/root token) and stores it in the
    Bruno env so the Demo App can authenticate as the workload.
 
+To reset before another attempt (removes the workload policy, safe + accounts, and the
+ISP `<app>-admins` role):
+
+```bash
+./remove.sh
+```
+
 ## Deployment Context
 
 This is a control-plane + API demo. The "workload" is the Bruno request context

--- a/demos/secrets_manager/bruno_api/demo_setup.md
+++ b/demos/secrets_manager/bruno_api/demo_setup.md
@@ -1,0 +1,71 @@
+# Bruno API Demo Setup
+
+This demo deploys the `poc-sm-saas-bruno` "ALM API Key Auth" collection against a live
+Secrets Manager tenant and prepares it to run from both the Bruno CLI and GUI.
+
+## Main Entry Point
+
+```bash
+cd "$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
+./setup.sh
+```
+
+`setup.sh`:
+
+1. Ensures the Bruno CLI (`bru`) is installed (`compute_init/ubuntu/install_bru.sh`).
+2. Clones the Bruno collection (`BRUNO_REPO`, default `David-Lang/poc-sm-saas-bruno`) into
+   the git-ignored `.collection/`.
+3. Generates a git-ignored Bruno environment (`environments/cybr.secret.bru`) from the tenant
+   service creds.
+4. Runs the **Setup App** section with `bru run` (creates ISP roles, safe + accounts,
+   workload, RBAC, and rotates the workload API key).
+5. Captures the workload API key (using the service/root token) and stores it in the
+   Bruno env so the Demo App can authenticate as the workload.
+
+## Deployment Context
+
+This is a control-plane + API demo. The "workload" is the Bruno request context
+authenticating as the application's machine identity. The Setup App section is driven by
+the service account; the Demo App section runs as the workload.
+
+## Required Environment
+
+Prerequisites:
+
+- Linux/macOS with `bash`, `curl`, `jq`, `git`, and the GitHub CLI (`gh`, authenticated
+  to clone `BRUNO_REPO`).
+- Node.js + the Bruno CLI (`@usebruno/cli`) — installed by `setup.sh` if missing.
+- `CYBR_DEMOS_PATH` exported; tenant vars via `demos/setup_env.sh` (`tenant_vars.sh` or
+  environment): `LAB_ID`, `TENANT_ID`, `TENANT_SUBDOMAIN`, `CLIENT_ID`, `CLIENT_SECRET`.
+- The service account must have System Administrator + Conjur Cloud Admin rights.
+
+Inputs (env-overridable):
+
+- `UseCaseAlmAppName` — application name (default `poc-alm-app`).
+- `BRUNO_REPO` — collection repo to clone (default `David-Lang/poc-sm-saas-bruno`).
+
+The Bruno environment is generated, not committed. Real service creds live only in the
+git-ignored `.collection/collection/environments/cybr.secret.bru`.
+
+## What Gets Deployed
+
+CyberArk-side (via the Setup App section):
+
+- ISP roles for the app admins and service user
+- Privilege Cloud safe `data/vault/<app>` with sample accounts
+- Secrets Manager workload `data/<app>/<app>-workload` (+ rotated API key)
+- RBAC grants for the workload to the safe
+
+Local artifacts (git-ignored):
+
+- `.collection/` (cloned collection)
+- `.collection/collection/environments/cybr.secret.bru` (generated env + captured key)
+
+## Troubleshooting Setup
+
+- If `gh repo clone` fails, confirm `gh auth status` and access to `BRUNO_REPO`.
+- If `bru` install fails, install Node.js 20+ and `npm install -g @usebruno/cli` manually.
+- If the workload key capture fails, confirm the service account has Conjur Cloud Admin
+  rights and that the Setup App section created the workload.
+- Re-running `setup.sh` may show "already exists" errors from the create steps; these are
+  non-fatal (the key is re-captured each run).

--- a/demos/secrets_manager/bruno_api/demo_validation.md
+++ b/demos/secrets_manager/bruno_api/demo_validation.md
@@ -1,0 +1,81 @@
+# Bruno API Demo Validation
+
+Validates that an application workload can authenticate to Secrets Manager with its API
+key and retrieve secrets, using the `poc-sm-saas-bruno` collection — via both the Bruno
+CLI and the Bruno GUI.
+
+## Start Here
+
+Identify the objects created by setup (default `UseCaseAlmAppName=poc-alm-app`):
+
+- Workload (machine identity): `data/<app>/<app>-workload`
+- Safe / accounts: `data/vault/<app>/account-ssh-user1`, `account-ssh-user2`
+- Bruno environment: `.collection/collection/environments/cybr.secret.bru` (holds the
+  service creds + captured `almAppName_workload_ApiKey`)
+
+## About
+
+- **CyberArk Identity** issues the service-account platform token used during setup.
+- **Secrets Manager (Conjur)** authenticates the workload via its API key and authorizes
+  reads against the synced safe.
+- **Bruno** drives the API calls; the same collection runs in the CLI and the GUI.
+
+## Workflow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as Bruno (Demo App)
+    participant SM as Secrets Manager (Conjur)
+    participant Vault as Privilege Cloud Safe
+
+    App->>SM: POST authn/conjur/host%2Fdata%2F<app>%2F<app>-workload/authenticate (API key)
+    SM-->>App: session token
+    App->>Vault: GET secrets/.../account-ssh-user1/password (session token)
+    Vault-->>App: secret value
+```
+
+## Core Validation (CLI)
+
+```bash
+cd "$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
+./demo.sh
+```
+
+Expect the `bru run` summary to show the Demo App requests passing:
+`Authenticate`, `List Secrets`, `Retrieve Secret`, `Retrieve Secrets (Batch) v2`.
+
+## Pattern 1: CLI (`bru run`)
+
+- What it does: runs the Demo App section headless with the `cybr.secret` environment.
+- What to validate: `Authenticate` returns a session token; the retrieve calls return
+  secret values (masked in logs).
+- CyberArk behavior: the workload authenticates with its API key (not a human/service
+  credential) and is authorized only for its app's safe (least privilege).
+
+## Pattern 2: Bruno GUI
+
+- Open Bruno and open the cloned collection at
+  `.collection/collection` (`bruno.json`).
+- Enable Bruno developer settings (allows dynamic variable/session capture).
+- Select the `cybr.secret` environment.
+- Click through **1 Setup App** top-to-bottom (first time), then **2 Demo App**
+  top-to-bottom.
+- What to validate: each request returns 200; the environment's `almAppName_workload_ApiKey`
+  and `useCaseAlmAppName.sessionToken` populate as you run the steps.
+
+## Compare The Patterns
+
+- **CLI** is repeatable/automatable (CI, scripted demos).
+- **GUI** is best for interactive, step-by-step walkthroughs that show each request and
+  response and how variables chain.
+
+## Troubleshooting
+
+- `Authenticate` 401: the workload API key is stale/missing — re-run `./setup.sh` to
+  re-capture it into the env.
+- Retrieve returns 403: confirm the workload's RBAC grant to the safe was created.
+- GUI variables not populating: enable Bruno developer settings and confirm the `cybr.secret`
+  environment is selected.
+- The `poc-cdn-isp` environment in the collection is an example and may contain stale or
+  placeholder values — use the generated `cybr.secret` environment for this demo.

--- a/demos/secrets_manager/bruno_api/demo_validation.md
+++ b/demos/secrets_manager/bruno_api/demo_validation.md
@@ -29,10 +29,13 @@ sequenceDiagram
     participant SM as Secrets Manager (Conjur)
     participant Vault as Privilege Cloud Safe
 
+    Note over Vault,SM: Vault Synchronizer syncs the safe into Conjur (one-way, background)
+    Vault-->>SM: accounts -> data/vault/<app>/... variables
+
     App->>SM: POST authn/conjur/host%2Fdata%2F<app>%2F<app>-workload/authenticate (API key)
     SM-->>App: session token
-    App->>Vault: GET secrets/.../account-ssh-user1/password (session token)
-    Vault-->>App: secret value
+    App->>SM: GET secrets/conjur/variable/data/vault/<app>/account-ssh-user1/password (session token)
+    SM-->>App: secret value
 ```
 
 ## Core Validation (CLI)
@@ -42,14 +45,19 @@ cd "$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
 ./demo.sh
 ```
 
-Expect the `bru run` summary to show the Demo App requests passing:
-`Authenticate`, `List Secrets`, `Retrieve Secret`, `Retrieve Secrets (Batch) v2`.
+`demo.sh` narrates the flow: it prints the app/identity context, the planned API
+calls, runs the Demo App section with `bru run`, then shows each request and its
+response. Expect all four requests to pass, in order:
+`Authenticate`, `Retrieve Secret`, `Retrieve Secrets (Batch) v2`, `List Secrets`.
+The Conjur session token is masked in the output; the sample account secret values
+are shown (they are fake lab data).
 
 ## Pattern 1: CLI (`bru run`)
 
 - What it does: runs the Demo App section headless with the `cybr.secret` environment.
-- What to validate: `Authenticate` returns a session token; the retrieve calls return
-  secret values (masked in logs).
+- What to validate: `Authenticate` returns a session token (masked in the output);
+  the retrieve calls return the sample account secret values and `List Secrets` shows
+  only this app's variables.
 - CyberArk behavior: the workload authenticates with its API key (not a human/service
   credential) and is authorized only for its app's safe (least privilege).
 

--- a/demos/secrets_manager/bruno_api/info.yaml
+++ b/demos/secrets_manager/bruno_api/info.yaml
@@ -1,0 +1,7 @@
+Category: "Conjur Cloud"
+Name: "bruno_api"
+Docs: "https://github.com/David-Lang/cybr-demos/tree/main/demos/secrets_manager/bruno_api"
+DemoScript: "demo.sh"
+SetupScript: "setup.sh"
+Enabled: false
+IsSetup: false

--- a/demos/secrets_manager/bruno_api/remove.sh
+++ b/demos/secrets_manager/bruno_api/remove.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# shellcheck disable=SC2059
+# Tears down an ALM app created by the Bruno demo:
+#   - deletes the Conjur workload policy branch data/<app>
+#   - deletes the Privilege Cloud safe <app> (accounts first, then the safe)
+#   - best-effort: deletes the ISP "<app>-admins" role
+#
+# Target app resolves from APP_NAME, else "<UseCaseAlmAppName base>-<LAB_ID>".
+set -euo pipefail
+
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+
+APP_BASE="${UseCaseAlmAppName:-poc-alm-app}"
+APP_NAME="${APP_NAME:-${APP_BASE}-${LAB_ID:-}}"
+
+main() {
+  : "${TENANT_ID:?TENANT_ID must be set}"
+  : "${TENANT_SUBDOMAIN:?TENANT_SUBDOMAIN must be set}"
+  case "$APP_NAME" in
+    ""|*-) printf "ERROR: set APP_NAME (or LAB_ID) to the app to remove.\n" >&2; exit 1 ;;
+  esac
+
+  local isp_id="$TENANT_ID" isp_subdomain="$TENANT_SUBDOMAIN"
+  local client_id="$CLIENT_ID" client_secret="$CLIENT_SECRET"
+
+  printf "\nRemoving ALM app: %s\n" "$APP_NAME"
+  local identity_token conjur_token
+  identity_token=$(get_identity_token "$isp_id" "$client_id" "$client_secret")
+  conjur_token=$(get_conjur_token "$isp_subdomain" "$identity_token")
+
+  # 1. Delete the Conjur workload policy branch (data/<app>).
+  printf "\n[conjur] deleting policy data/%s\n" "$APP_NAME"
+  patch_conjur_policy "$isp_subdomain" "$conjur_token" "data" \
+    "$(printf -- '---\n- !delete\n  record: !policy %s\n' "$APP_NAME")"
+
+  # 2. Delete Privilege Cloud safe accounts, then the safe.
+  delete_safe_accounts "$isp_subdomain" "$identity_token" "$APP_NAME"
+  delete_safe "$isp_subdomain" "$identity_token" "$APP_NAME"
+
+  # 3. Best-effort: delete the ISP "<app>-admins" role.
+  if delete_app_admins_role "$isp_id" "$identity_token" "${APP_NAME}-admins"; then
+    printf "[isp] deleted role %s-admins\n" "$APP_NAME"
+  else
+    printf "[isp] role %s-admins not deleted (remove manually if it lingers)\n" "$APP_NAME"
+  fi
+
+  printf "\nRemoval complete for %s\n" "$APP_NAME"
+}
+
+delete_safe_accounts() {
+  # $1 isp_subdomain, $2 identity_token, $3 safe
+  local sub="$1" token="$2" safe="$3" ids id
+  ids=$(curl -s --location \
+    "https://$sub.privilegecloud.cyberark.cloud/PasswordVault/API/Accounts?filter=safeName%20eq%20$safe" \
+    --header "Authorization: Bearer $token" | jq -r '.value[].id // empty' 2>/dev/null)
+  for id in $ids; do
+    printf "[vault] deleting account %s in safe %s\n" "$id" "$safe"
+    curl -s --request DELETE \
+      --location "https://$sub.privilegecloud.cyberark.cloud/PasswordVault/API/Accounts/$id" \
+      --header "Authorization: Bearer $token" >/dev/null
+  done
+}
+
+delete_app_admins_role() {
+  # $1 isp_id, $2 identity_token, $3 role_name  (best-effort)
+  # Note: deletion requires the role's RowKey (looked up via Redrock) passed as
+  # "Name" to /SaasManage/DeleteRole. /Roles/DeleteRole silently no-ops here.
+  local isp="$1" token="$2" role="$3" rowkey resp
+  rowkey=$(curl -s --request POST "https://$isp.id.cyberark.cloud/Redrock/query" \
+    --header "Authorization: Bearer $token" --header "Content-Type: application/json" \
+    --data "$(jq -cn --arg n "$role" '{Script: ("SELECT ID FROM Role WHERE Name=\u0027" + $n + "\u0027")}')" \
+    | jq -r '.Result.Results[0].Row.ID // empty' 2>/dev/null)
+  [ -n "$rowkey" ] || return 1
+  resp=$(curl -s --request POST "https://$isp.id.cyberark.cloud/SaasManage/DeleteRole" \
+    --header "Authorization: Bearer $token" --header "Content-Type: application/json" \
+    --data "$(jq -cn --arg id "$rowkey" '{Name: $id}')")
+  [ "$(echo "$resp" | jq -r '.success // false' 2>/dev/null)" = "true" ]
+}
+
+main "$@"

--- a/demos/secrets_manager/bruno_api/remove.sh
+++ b/demos/secrets_manager/bruno_api/remove.sh
@@ -8,6 +8,10 @@
 # Target app resolves from APP_NAME, else "<UseCaseAlmAppName base>-<LAB_ID>".
 set -euo pipefail
 
+# Locate the repo root from this script if the lab bootstrap hasn't exported it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${CYBR_DEMOS_PATH:=$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
 source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 APP_BASE="${UseCaseAlmAppName:-poc-alm-app}"

--- a/demos/secrets_manager/bruno_api/setup.sh
+++ b/demos/secrets_manager/bruno_api/setup.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# shellcheck disable=SC2059
+# Sets up the "ALM API Key Auth" Bruno collection demo:
+#   - installs the Bruno CLI (bru) if needed
+#   - clones the poc-sm-saas-bruno collection
+#   - generates a git-ignored Bruno environment from the tenant service creds
+#   - runs the Setup App section via `bru run` (showcases the Secrets Manager API)
+#   - captures the workload API key (via the service/root token) into the env so the
+#     Demo App (CLI or GUI) can authenticate as the workload
+set -euo pipefail
+
+source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
+
+demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"
+
+# Inputs (env-overridable)
+BRUNO_REPO="${BRUNO_REPO:-David-Lang/poc-sm-saas-bruno}"
+BRUNO_BRANCH="${BRUNO_BRANCH:-main}"
+APP_BASE="${UseCaseAlmAppName:-poc-alm-app}"
+# Env name ends in ".secret" so the generated file (cybr.secret.bru) is:
+#  - git-ignored by the collection's own .gitignore (*.secret.*), and
+#  - obviously secret-bearing by name.
+ENV_NAME="cybr.secret"
+
+WORK_DIR="$demo_path/.collection"
+COLLECTION_DIR="$WORK_DIR/collection"
+ENV_FILE="$COLLECTION_DIR/environments/$ENV_NAME.bru"
+
+main() {
+  set_variables
+
+  ensure_tool_installed bru
+
+  clone_collection
+  write_env_file
+  run_setup_app
+  capture_workload_api_key
+
+  printf "\nSetup complete.\n"
+  printf "  Collection: %s\n" "$COLLECTION_DIR"
+  printf "  Bruno env:  %s (env name: %s)\n" "$ENV_FILE" "$ENV_NAME"
+  printf "  App name:   %s\n" "$app_name"
+  printf "Run the demo with: %s/demo.sh\n" "$demo_path"
+}
+
+# shellcheck disable=SC2153
+set_variables() {
+  : "${TENANT_ID:?TENANT_ID must be set}"
+  : "${TENANT_SUBDOMAIN:?TENANT_SUBDOMAIN must be set}"
+  : "${LAB_ID:?LAB_ID must be set (used to build a stable, idempotent app name)}"
+  isp_id="$TENANT_ID"
+  isp_subdomain="$TENANT_SUBDOMAIN"
+  client_id="$CLIENT_ID"
+  client_secret="$CLIENT_SECRET"
+  # Stable app name derived from LAB_ID -> idempotent across runs.
+  app_name="${APP_BASE}-${LAB_ID}"
+}
+
+clone_collection() {
+  if [ -d "$COLLECTION_DIR" ]; then
+    printf "\nRefreshing existing collection clone\n"
+    git -C "$WORK_DIR" pull --ff-only 2>/dev/null || true
+  else
+    printf "\nCloning Bruno collection %s (branch %s)\n" "$BRUNO_REPO" "$BRUNO_BRANCH"
+    gh repo clone "$BRUNO_REPO" "$WORK_DIR" -- -b "$BRUNO_BRANCH"
+  fi
+  [ -f "$COLLECTION_DIR/bruno.json" ] || {
+    printf "ERROR: bruno.json not found under %s\n" "$COLLECTION_DIR" >&2
+    exit 1
+  }
+}
+
+# Generate a git-ignored Bruno environment from the service-account creds.
+write_env_file() {
+  printf "\nWriting Bruno environment %s\n" "$ENV_FILE"
+  mkdir -p "$COLLECTION_DIR/environments"
+  cat > "$ENV_FILE" <<EOF
+vars {
+  ConjurAccount: conjur
+  UseCaseAlmAppName: ${app_name}
+  LabId: ${LAB_ID}
+  IspTenantId: ${isp_id}
+  IspSubDomain: ${isp_subdomain}
+  IspServiceClientId: ${client_id}
+  IspServiceClientSecret: ${client_secret}
+  identityToken:
+  conjurSessionToken:
+  almAppName_workload_ApiKey:
+}
+EOF
+  chmod 600 "$ENV_FILE"
+}
+
+run_setup_app() {
+  printf "\nRunning Bruno Setup App section (bru run)\n"
+  ( cd "$COLLECTION_DIR" && bru run "Use Cases/ALM API Key Auth/1 Setup App" -r --env "$ENV_NAME" ) || {
+    printf "NOTE: some Setup App steps may report errors on re-run (already-exists); continuing.\n"
+  }
+}
+
+# Rotate + capture the workload API key using the service/root token, then persist
+# it into the Bruno env so the Demo App can authenticate as the workload.
+capture_workload_api_key() {
+  printf "\nCapturing workload API key (via service token)\n"
+  local workload="data/${app_name}/${app_name}-workload"
+  local identity_token conjur_token api_key
+  identity_token=$(get_identity_token "$isp_id" "$client_id" "$client_secret")
+  conjur_token=$(get_conjur_token "$isp_subdomain" "$identity_token")
+  api_key=$(rotate_workload_api_key "$isp_subdomain" "$conjur_token" "$workload")
+  # A Conjur API key is a long alphanumeric string; reject error bodies (JSON/HTML).
+  if ! printf '%s' "$api_key" | grep -qE '^[A-Za-z0-9]{40,}$'; then
+    printf "ERROR: did not get a valid workload API key for host:%s\n" "$workload" >&2
+    printf "       (the Setup App may not have created the workload). Response:\n%s\n" "$api_key" >&2
+    exit 1
+  fi
+  set_env_var "almAppName_workload_ApiKey" "$api_key"
+}
+
+# Set a var value inside the generated Bruno env file.
+set_env_var() {
+  local key="$1" value="$2"
+  # Replace the "  key:" line (value may be empty or present).
+  local tmp
+  tmp="$(mktemp)"
+  awk -v k="  $key:" -v v="  $key: $value" '
+    { if (index($0, k) == 1) print v; else print $0 }
+  ' "$ENV_FILE" > "$tmp" && mv "$tmp" "$ENV_FILE"
+}
+
+main "$@"

--- a/demos/secrets_manager/bruno_api/setup.sh
+++ b/demos/secrets_manager/bruno_api/setup.sh
@@ -9,6 +9,10 @@
 #     Demo App (CLI or GUI) can authenticate as the workload
 set -euo pipefail
 
+# Locate the repo root from this script if the lab bootstrap hasn't exported it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${CYBR_DEMOS_PATH:=$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
 source "$CYBR_DEMOS_PATH/demos/setup_env.sh"
 
 demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/bruno_api"

--- a/demos/secrets_manager/github.com/README.md
+++ b/demos/secrets_manager/github.com/README.md
@@ -52,7 +52,7 @@ sequenceDiagram
 - `demo.sh`
   Runs the demo: triggers the GitHub Actions workflows on `GH_REF` (default `aardvark`) via the `gh` CLI and lists the runs.
 - `setup/vars.env`
-  Shared demo configuration: `SAFE_NAME`, `JWT_CLAIM_IDENTITY`, `GH_REPO`, `GH_ENVIRONMENTS`, `TRUFFLEHOG_REPOS`, `TFVAR_*` (all env-overridable).
+  Shared demo configuration: `SAFE_NAME`, `JWT_CLAIM_IDENTITY`, `GH_REPO`, `GH_ENVIRONMENTS`, `TRUFFLEHOG_OWNER`, `TFVAR_*` (all env-overridable).
 - `setup/vault/setup.sh`
   Creates the demo safe, grants required members, and creates `account-ssh-user-1`.
 - `setup/conjur/setup.sh`

--- a/demos/secrets_manager/github.com/demo.sh
+++ b/demos/secrets_manager/github.com/demo.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 demo_path="$CYBR_DEMOS_PATH/demos/secrets_manager/github.com"
 
-# Load demo inputs (GH_REPO, GH_ENVIRONMENTS, TRUFFLEHOG_REPOS, TFVAR_*).
+# Load demo inputs (GH_REPO, GH_ENVIRONMENTS, TRUFFLEHOG_OWNER, TFVAR_*).
 set -a
 # shellcheck disable=SC1091
 source "$demo_path/setup/vars.env"
@@ -42,11 +42,11 @@ main() {
   # Terraform reuses the same secret id as the other demos (no AWS JSON needed).
   run_workflow "sm-plugin-jwt-terraform.yml"
 
-  # Multi-scan needs a repo list.
-  if [ -n "${TRUFFLEHOG_REPOS:-}" ]; then
+  # Multi-scan scans all public repos of a GitHub owner (TRUFFLEHOG_OWNER).
+  if [ -n "${TRUFFLEHOG_OWNER:-}" ]; then
     run_workflow "trufflehog-multi-scan.yml"
   else
-    skip_workflow "trufflehog-multi-scan.yml (set TRUFFLEHOG_REPOS to run)"
+    skip_workflow "trufflehog-multi-scan.yml (set TRUFFLEHOG_OWNER to a GitHub account/owner to run)"
   fi
 
   printf "\nDispatched. Recent runs:\n\n"

--- a/demos/secrets_manager/github.com/demo_setup.md
+++ b/demos/secrets_manager/github.com/demo_setup.md
@@ -54,7 +54,7 @@ The setup uses `setup/vars.env` as the shared demo configuration file. It reads 
 - `JWT_CLAIM_IDENTITY` — the GitHub `actor` claim value (your GitHub username). Required; the default is a placeholder.
 - `GH_REPO` — target GitHub repository `owner/repo` (default `David-Lang/idira-poc-github-actions`).
 - `GH_ENVIRONMENTS` — environments to create/seed (default `dev staging main terraform`).
-- `TRUFFLEHOG_REPOS` — optional repo list for the trufflehog demo.
+- `TRUFFLEHOG_OWNER` — optional GitHub account/owner whose public repos the trufflehog multi-scan scans.
 - `TFVAR_SSL_CERT`, `TFVAR_sm_secret_id_1` — optional Terraform overrides (derived if blank).
 
 ## Setup Flow
@@ -121,7 +121,7 @@ CyberArk-side resources:
 
 GitHub-side resources (in `GH_REPO`):
 
-- repository variables: `SM_URL`, `SM_ACCOUNT`, `SM_JWT_AUTHN_ID`, `SM_SECRET_ID_1`, `SM_SECRET_ID_2` (and optional `TRUFFLEHOG_REPOS`)
+- repository variables: `SM_URL`, `SM_ACCOUNT`, `SM_JWT_AUTHN_ID`, `SM_SECRET_ID_1`, `SM_SECRET_ID_2` (and optional `TRUFFLEHOG_OWNER`)
 - repository secrets: `SM_USERNAME`, `SM_API_KEY`
 - environments: `dev`, `staging`, `main`, and `terraform` (with `TFVAR_*`)
 

--- a/demos/secrets_manager/github.com/demo_validation.md
+++ b/demos/secrets_manager/github.com/demo_validation.md
@@ -88,7 +88,7 @@ GH_REF=main ./demo.sh   # override the ref
 ```
 
 `demo.sh` dispatches the core workflows, conditionally runs `sm-plugin-jwt-terraform`
-(when `TFVAR_sm_secret_id_1` is set) and `trufflehog-multi-scan` (when `TRUFFLEHOG_REPOS`
+(when `TFVAR_sm_secret_id_1` is set) and `trufflehog-multi-scan` (when `TRUFFLEHOG_OWNER`
 is set), and lists the resulting runs. The patterns below explain what each proves.
 
 ## Pattern 1: GitHub OIDC JWT (plugin and direct)

--- a/demos/secrets_manager/github.com/setup/github/init-gh-vars-secrets.sh
+++ b/demos/secrets_manager/github.com/setup/github/init-gh-vars-secrets.sh
@@ -19,7 +19,7 @@ Value sources:
     SM_JWT_AUTHN_ID
     SM_SECRET_ID_1
     SM_SECRET_ID_2
-    TRUFFLEHOG_REPOS              optional
+    TRUFFLEHOG_OWNER             optional
     SM_USERNAME                   secret
     SM_API_KEY                    secret
 
@@ -285,7 +285,7 @@ REPO_REQUIRED_VARS=(
 )
 
 REPO_OPTIONAL_VARS=(
-  TRUFFLEHOG_REPOS
+  TRUFFLEHOG_OWNER
 )
 
 REPO_SECRETS=(

--- a/demos/secrets_manager/github.com/setup/vars.env
+++ b/demos/secrets_manager/github.com/setup/vars.env
@@ -10,8 +10,9 @@ JWT_CLAIM_IDENTITY="${JWT_CLAIM_IDENTITY:-INPUT_REQUIRED: github-name}"
 GH_REPO="${GH_REPO:-David-Lang/idira-poc-github-actions}"
 GH_ENVIRONMENTS="${GH_ENVIRONMENTS:-dev staging main terraform}"
 
-# Optional: trufflehog-multi-scan repo list (space or newline separated).
-TRUFFLEHOG_REPOS="${TRUFFLEHOG_REPOS:-}"
+# Optional: trufflehog-multi-scan target. A GitHub account/owner (user or org);
+# the workflow scans all of that owner's public repos.
+TRUFFLEHOG_OWNER="${TRUFFLEHOG_OWNER:-}"
 
 # Terraform demo (JWT auth) optional overrides; blank values are derived from
 # the SM_* values produced by setup. TFVAR_sm_secret_id_1 reuses SM_SECRET_ID_1


### PR DESCRIPTION
Adds a new Secrets Manager demo that showcases the SM REST API via the poc-sm-saas-bruno 'ALM API Key Auth' Bruno collection, runnable from both the Bruno CLI and GUI.

## What's included
- **demos/secrets_manager/bruno_api/** new demo:
  - setup.sh: installs the Bruno CLI, clones the collection, generates a git-ignored Bruno env (cybr.secret.bru, chmod 600) from the tenant service creds, runs the Setup App section, and captures the workload API key.
  - demo.sh: narrated Demo App walkthrough (workload authenticate with API key -> retrieve secrets); prints app/identity context and the planned API calls, then renders each request/response from a temp JSON report (Conjur session token masked; sample lab secret values shown).
  - remove.sh: tears down the app (Conjur workload policy, Privilege Cloud safe + accounts, ISP <app>-admins role via /SaasManage/DeleteRole).
  - README.md, demo_setup.md, demo_validation.md per the repo doc guidelines (validation Mermaid diagram shows the app talking only to Secrets Manager; the safe is synced one-way into Conjur).
- **compute_init/ubuntu/install_bru.sh**: Bruno CLI installer.
- Scripts self-locate CYBR_DEMOS_PATH from their own path when the lab bootstrap hasn't exported it.
- Idempotent app name derived from LAB_ID (UseCaseAlmAppName=<base>-<LAB_ID>).
- Also includes a small github.com demo tweak: trufflehog multi-scan targets a GitHub owner (all public repos).

## Validation
- setup.sh 26/26 and demo.sh 4/4 against a live tenant.

Note: setup.sh currently needs BRUNO_BRANCH=cheetah until the poc-sm-saas-bruno idempotency fix merges to that repo's main.